### PR TITLE
docs(arch): design agents CRUD chunk 04

### DIFF
--- a/agents/architect/docs/00-overview.md
+++ b/agents/architect/docs/00-overview.md
@@ -94,7 +94,7 @@ Filesystem mirrors the DB: `/data/orgs/{slug}/agents/{slug}/` holds SOUL.md, AGE
 | 01 | Organizations CRUD             | —          | ORM model, service, routes, Pydantic models         | implemented     | 2026-04-05 |
 | 02 | API Key Auth                   | 01         | API key model, hashing, auth dependency, scopes, key routes | not started     | —          |
 | 03 | Agent Filesystem & Templates   | 01         | SOUL.md.j2, AGENTS.md.j2, HEARTBEAT.md.j2, TOOLS.md.j2, memory stubs, gateway.json schema, FilesystemService, config | designed        | 2026-04-06 |
-| 04 | Agents CRUD                    | 01, 02, 03 | ORM model, service, routes, file read/write routes   | not started     | —          |
+| 04 | Agents CRUD                    | 01, 02, 03 | ORM model, service, routes, file read/write routes   | designed        | 2026-04-06 |
 | 05 | Adapter Interface              | 04         | BaseAdapter ABC, RunContext, RunResult, registry      | not started     | —          |
 | 06 | Claude Code Adapter            | 05         | ClaudeCodeAdapter implementation                     | not started     | —          |
 | 07 | Celery Setup & Run Execution   | 05, 06     | Celery app, Redis broker, execute_agent_run task     | not started     | —          |

--- a/agents/architect/docs/04-agents-crud.md
+++ b/agents/architect/docs/04-agents-crud.md
@@ -5,8 +5,12 @@ Implement the Agent entity: ORM model, service, REST routes including file manag
 
 ## Depends On
 - Chunk 01 (Organizations)
-- Chunk 02 (API Key Auth — routes require auth)
-- Chunk 03 (Filesystem & Templates — agent creation scaffolds directory)
+- Chunk 02 (API Key Auth — routes require auth; scopes `agents:read` / `agents:write`)
+- Chunk 03 (Filesystem & Templates — agent creation scaffolds directory via `FilesystemService`)
+
+## Referenced By
+- Chunk 05 (Adapter Interface — adapters receive an `Agent` record and its `dir_path`)
+- Chunk 08 (Runs CRUD — runs are FK-linked to `agents.id`)
 
 ## Deliverables
 
@@ -21,10 +25,10 @@ agents
   name            VARCHAR NOT NULL       -- unique within org
   slug            VARCHAR NOT NULL       -- unique within org
   dir_path        VARCHAR NOT NULL       -- absolute path to agent dir on disk
-  adapter_type    VARCHAR NOT NULL       -- "claude_code", "codex", "anthropic_api"
+  adapter_type    VARCHAR NOT NULL       -- validated against KNOWN_ADAPTER_TYPES
   adapter_config  JSON                   -- adapter-specific settings (model, flags)
   skills          JSON                   -- ["code_review", "testing", "deployment"]
-  status          VARCHAR NOT NULL       -- active, paused, error, archived
+  status          VARCHAR NOT NULL       -- "active" | "inactive" | "archived"
   heartbeat_interval_seconds  INT DEFAULT 0  -- 0 = disabled
   last_heartbeat_at  TIMESTAMP NULL
   created_at      TIMESTAMP
@@ -34,23 +38,33 @@ agents
 Constraints: `UniqueConstraint("org_id", "name")`, `UniqueConstraint("org_id", "slug")`.
 Relationship: `Organization.agents` ↔ `Agent.organization`.
 
+**Status values (canonical):** `active`, `inactive`, `archived`.
+- `inactive` replaces the earlier "paused" — aligns with gateway.json schema from chunk 03.
+- `error` is not stored as a status; it is surfaced in the Run record (chunk 08), not on the agent.
+
+**`KNOWN_ADAPTER_TYPES`** (module-level constant in `services/agent.py`):
+```
+KNOWN_ADAPTER_TYPES = ["claude_code", "codex", "anthropic_api"]
+```
+`adapter_type` is validated against this list on create; unrecognised values are rejected with 422.
+
 ### 2. Pydantic Models — `models/agent.py`
 
 ```python
 class AgentCreate(BaseModel):
     name: str
-    adapter_type: str                    # "claude_code", "codex", "anthropic_api"
+    adapter_type: str                    # must be in KNOWN_ADAPTER_TYPES
     adapter_config: dict = {}
     skills: list[str] = []
     heartbeat_interval_seconds: int = 0
-    template: str = "default"           # which template to scaffold from
-    role: str | None = None             # passed to template
+    template: str = "default"           # Jinja2 template name (chunk 03)
+    role: str | None = None             # passed to template vars
 
 class AgentUpdate(BaseModel):
     name: str | None = None
     adapter_config: dict | None = None
     skills: list[str] | None = None
-    status: str | None = None           # active, paused, archived
+    status: str | None = None           # "active" | "inactive" | "archived"
     heartbeat_interval_seconds: int | None = None
 
 class AgentResponse(BaseModel):
@@ -79,35 +93,73 @@ class AgentFileContent(BaseModel):
 ### 3. Service — `services/agent.py`
 
 ```python
+KNOWN_ADAPTER_TYPES = ["claude_code", "codex", "anthropic_api"]
+
 class AgentService:
     def __init__(self, db: Session, filesystem: FilesystemService): ...
 
     def create(self, org: Organization, data: AgentCreate) -> Agent:
-        # 1. Generate slug from name
-        # 2. Scaffold agent directory via FilesystemService
-        # 3. Write gateway.json
-        # 4. Create DB record
+        # 1. Validate adapter_type in KNOWN_ADAPTER_TYPES → raise 422 if not
+        # 2. Generate slug from name (slugify)
+        # 3. Call filesystem.scaffold_agent_dir(
+        #        org_slug=org.slug,
+        #        agent_slug=slug,
+        #        base_path=settings.data_dir,
+        #        template_name=data.template,
+        #        template_vars={
+        #            "agent_name": data.name,
+        #            "agent_slug": slug,
+        #            "org_name": org.name,
+        #            "org_slug": org.slug,
+        #            "role": data.role or "",
+        #            "adapter_type": data.adapter_type,
+        #            "gateway_url": settings.gateway_url,
+        #            "created_at": utcnow().isoformat(),
+        #        },
+        #    ) → returns agent_dir (absolute path)
+        # 4. Call filesystem.write_gateway_json(agent_dir, {
+        #        "id": str(new_uuid),
+        #        "name": data.name,
+        #        "slug": slug,
+        #        "org_slug": org.slug,
+        #        "adapter_type": data.adapter_type,
+        #        "skills": data.skills,
+        #        "status": "active",
+        #        "heartbeat_interval_seconds": data.heartbeat_interval_seconds,
+        #        "gateway_url": settings.gateway_url,
+        #    })
+        # 5. Insert Agent row with dir_path=agent_dir, status="active"
         # Return agent
 
     def get_by_id(self, org_id: UUID, agent_id: UUID) -> Agent: ...
     def get_by_slug(self, org_id: UUID, slug: str) -> Agent: ...
     def get_by_id_or_slug(self, org_id: UUID, identifier: str) -> Agent:
-        # Try UUID first, then slug
+        # Try UUID parse first; if valid UUID call get_by_id, else get_by_slug
 
-    def list_by_org(self, org_id: UUID, status: str | None, adapter_type: str | None) -> list[Agent]: ...
+    def list_by_org(
+        self, org_id: UUID,
+        status: str | None = None,
+        adapter_type: str | None = None,
+    ) -> list[Agent]: ...
 
     def update(self, org_id: UUID, agent_id: UUID, data: AgentUpdate) -> Agent:
-        # Update DB record
-        # Update gateway.json on disk if relevant fields changed
+        # Update DB columns for any non-None field in data
+        # If any of {adapter_config, skills, status, heartbeat_interval_seconds}
+        #   changed → rewrite gateway.json via filesystem.write_gateway_json
+        # Return updated agent
 
     def archive(self, org_id: UUID, agent_id: UUID) -> Agent:
         # Soft delete: set status = "archived"
-        # Keep files on disk
+        # Rewrites gateway.json (status field)
+        # Files on disk are kept
 
     def get_agent_files(self, agent: Agent) -> list[str]: ...
     def read_agent_file(self, agent: Agent, path: str) -> str: ...
     def write_agent_file(self, agent: Agent, path: str, content: str) -> None: ...
 ```
+
+**gateway.json rewrite trigger fields:** `adapter_config`, `skills`, `status`, `heartbeat_interval_seconds`.
+Name/slug changes do NOT rewrite gateway.json (slug is immutable after creation).
 
 ### 4. Dependency Function — `services/__init__.py`
 
@@ -121,28 +173,73 @@ def get_agent_service(
 
 ### 5. Routes — `api/routes/agent.py`
 
-All routes require auth via `get_current_org` dependency. Org is resolved from API key.
+All routes require auth via `get_current_org`. Pattern from chunk 02:
+```python
+(org, key) = Depends(get_current_org)
+```
+Scope enforcement uses `require_scope(key, "agents:read")` or `require_scope(key, "agents:write")`.
 
 ```
-POST   /api/v1/agents                        → create agent
-GET    /api/v1/agents                         → list agents
-  Query: ?status=active&adapter_type=claude_code
-GET    /api/v1/agents/{agent_id}              → get agent (UUID or slug)
-PATCH  /api/v1/agents/{agent_id}              → update agent
-DELETE /api/v1/agents/{agent_id}              → archive agent (soft delete)
+POST   /api/v1/agents
+  Scope: agents:write
+  Body:  AgentCreate
+  Returns: AgentResponse 201
 
-GET    /api/v1/agents/{agent_id}/files        → list files in agent dir
-GET    /api/v1/agents/{agent_id}/files/{path:path} → read file
-PUT    /api/v1/agents/{agent_id}/files/{path:path} → write/update file
+GET    /api/v1/agents
+  Scope: agents:read
+  Query: ?status=active&adapter_type=claude_code
+  Returns: list[AgentResponse] 200
+
+GET    /api/v1/agents/{agent_id}
+  Scope: agents:read
+  Path:  agent_id = UUID or slug
+  Returns: AgentResponse 200
+
+PATCH  /api/v1/agents/{agent_id}
+  Scope: agents:write
+  Body:  AgentUpdate
+  Returns: AgentResponse 200
+
+DELETE /api/v1/agents/{agent_id}
+  Scope: agents:write
+  Action: soft-delete (archive)
+  Returns: AgentResponse 200
+
+GET    /api/v1/agents/{agent_id}/files
+  Scope: agents:read
+  Returns: AgentFileList 200
+
+GET    /api/v1/agents/{agent_id}/files/{path:path}
+  Scope: agents:read
+  Returns: AgentFileContent 200
+
+PUT    /api/v1/agents/{agent_id}/files/{path:path}
+  Scope: agents:write
+  Body:  AgentFileContent
+  Returns: 204
 ```
 
 ### 6. Register Router
 
-Add agent_router to `api/routes/__init__.py`.
+Add `agent_router` to `api/routes/__init__.py` and include in `main.py`.
+
+## Config
+
+No new environment variables. This chunk consumes:
+- `DATA_DIR` — agent filesystem root (from chunk 03)
+- `GATEWAY_URL` — injected into gateway.json and template vars (from chunk 03)
 
 ## Notes
+- Slug is derived from `name` at creation time and is immutable thereafter.
 - Agent identification accepts both UUID and slug (`get_by_id_or_slug`).
 - File endpoints use `{path:path}` to capture nested paths like `memory/long_term.md`.
-- All file operations are scoped to the agent's `dir_path` — path traversal is blocked by FilesystemService.
-- `adapter_type` is validated against known adapter types (for now: hard-coded list; later: AdapterRegistry).
-- `DELETE` is a soft delete — sets status to "archived", keeps files.
+- All file operations are scoped to the agent's `dir_path` — path traversal is blocked by `FilesystemService`.
+- `adapter_type` is validated against `KNOWN_ADAPTER_TYPES`; unknown values → 422.
+- `DELETE` is a soft delete — sets status to `"archived"`, keeps files on disk, rewrites gateway.json.
+
+## Change Log
+
+| Date       | Change                                                                                          |
+|------------|-------------------------------------------------------------------------------------------------|
+| 2026-04-06 | Initial draft                                                                                   |
+| 2026-04-06 | Reconciled against chunks 02 and 03: status values corrected (`inactive` replaces `paused`, `error` removed from agent status); added `Referenced By`; added per-route scope annotations; documented `get_current_org` tuple pattern; expanded `create` with full `template_vars` dict and `gateway.json` payload; specified gateway.json rewrite trigger fields in `update`; added `KNOWN_ADAPTER_TYPES` constant; added Config section |


### PR DESCRIPTION
Reconcile chunk 04 against now-complete chunks 02 and 03:
- Fix status values to active|inactive|archived (drop paused/error)
- Add Referenced By section (chunks 05, 08)
- Add per-route scope annotations (agents:read/write) with get_current_org pattern
- Expand create() with full template_vars dict and gateway.json payload
- Specify update() gateway.json rewrite triggers; mark slug as immutable
- Define KNOWN_ADAPTER_TYPES constant ["claude_code", "codex", "anthropic_api"]
- Add Config section referencing chunk 03 env vars
- Update overview table: status=designed, date=2026-04-06

https://claude.ai/code/session_01MZaEFtTNsSheL2u1f4VKLo