### PR TITLE
feat(agents): implement agents CRUD (chunk 04)

### DIFF
--- a/src/zenve/api/routes/__init__.py
+++ b/src/zenve/api/routes/__init__.py
@@ -1,6 +1,7 @@
+from .agent import router as agent_router
 from .api_key import router as api_key_router
 from .auth import router as auth_router
 from .core import router as core_router
 from .org import router as org_router
 
-__all__ = ["api_key_router", "auth_router", "core_router", "org_router"]
+__all__ = ["agent_router", "api_key_router", "auth_router", "core_router", "org_router"]

--- a/src/zenve/api/routes/agent.py
+++ b/src/zenve/api/routes/agent.py
@@ -1,0 +1,104 @@
+from fastapi import APIRouter, Depends, Query, status
+
+from zenve.db.models import ApiKeyRecord, Organization
+from zenve.models.agent import (
+    AgentCreate,
+    AgentFileContent,
+    AgentFileList,
+    AgentResponse,
+    AgentUpdate,
+)
+from zenve.services import get_agent_service
+from zenve.services.agent import AgentService
+from zenve.utils.api_key_auth import require_scope
+
+router = APIRouter(prefix="/api/v1/agents", tags=["agents"])
+
+
+@router.post("", response_model=AgentResponse, status_code=status.HTTP_201_CREATED)
+def create_agent(
+    body: AgentCreate,
+    auth: tuple[Organization, ApiKeyRecord] = Depends(require_scope("agents:write")),
+    service: AgentService = Depends(get_agent_service),
+):
+    org, _ = auth
+    return service.create(org, body)
+
+
+@router.get("", response_model=list[AgentResponse])
+def list_agents(
+    agent_status: str | None = Query(None, alias="status"),
+    adapter_type: str | None = Query(None),
+    auth: tuple[Organization, ApiKeyRecord] = Depends(require_scope("agents:read")),
+    service: AgentService = Depends(get_agent_service),
+):
+    org, _ = auth
+    return service.list_by_org(org.id, status=agent_status, adapter_type=adapter_type)
+
+
+@router.get("/{agent_id}", response_model=AgentResponse)
+def get_agent(
+    agent_id: str,
+    auth: tuple[Organization, ApiKeyRecord] = Depends(require_scope("agents:read")),
+    service: AgentService = Depends(get_agent_service),
+):
+    org, _ = auth
+    return service.get_by_id_or_slug(org.id, agent_id)
+
+
+@router.patch("/{agent_id}", response_model=AgentResponse)
+def update_agent(
+    agent_id: str,
+    body: AgentUpdate,
+    auth: tuple[Organization, ApiKeyRecord] = Depends(require_scope("agents:write")),
+    service: AgentService = Depends(get_agent_service),
+):
+    org, _ = auth
+    return service.update(org.id, agent_id, body)
+
+
+@router.delete("/{agent_id}", response_model=AgentResponse)
+def archive_agent(
+    agent_id: str,
+    auth: tuple[Organization, ApiKeyRecord] = Depends(require_scope("agents:write")),
+    service: AgentService = Depends(get_agent_service),
+):
+    org, _ = auth
+    return service.archive(org.id, agent_id)
+
+
+@router.get("/{agent_id}/files", response_model=AgentFileList)
+def list_agent_files(
+    agent_id: str,
+    auth: tuple[Organization, ApiKeyRecord] = Depends(require_scope("agents:read")),
+    service: AgentService = Depends(get_agent_service),
+):
+    org, _ = auth
+    agent = service.get_by_id_or_slug(org.id, agent_id)
+    return AgentFileList(files=service.get_agent_files(agent))
+
+
+@router.get("/{agent_id}/files/{path:path}", response_model=AgentFileContent)
+def read_agent_file(
+    agent_id: str,
+    path: str,
+    auth: tuple[Organization, ApiKeyRecord] = Depends(require_scope("agents:read")),
+    service: AgentService = Depends(get_agent_service),
+):
+    org, _ = auth
+    agent = service.get_by_id_or_slug(org.id, agent_id)
+    content = service.read_agent_file(agent, path)
+    return AgentFileContent(path=path, content=content)
+
+
+@router.put("/{agent_id}/files/{path:path}", status_code=status.HTTP_204_NO_CONTENT)
+def write_agent_file(
+    agent_id: str,
+    path: str,
+    body: AgentFileContent,
+    auth: tuple[Organization, ApiKeyRecord] = Depends(require_scope("agents:write")),
+    service: AgentService = Depends(get_agent_service),
+):
+    org, _ = auth
+    agent = service.get_by_id_or_slug(org.id, agent_id)
+    service.write_agent_file(agent, path, body.content)

--- a/src/zenve/db/models.py
+++ b/src/zenve/db/models.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import ForeignKey, String, func
+from sqlalchemy import ForeignKey, JSON, String, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from zenve.db.database import Base
@@ -36,6 +36,9 @@ class Organization(Base):
     api_keys: Mapped[list["ApiKeyRecord"]] = relationship(
         back_populates="organization", cascade="all, delete-orphan"
     )
+    agents: Mapped[list["Agent"]] = relationship(
+        back_populates="organization", cascade="all, delete-orphan"
+    )
 
 
 class ApiKeyRecord(Base):
@@ -56,3 +59,33 @@ class ApiKeyRecord(Base):
     expires_at: Mapped[datetime | None] = mapped_column(nullable=True)
 
     organization: Mapped["Organization"] = relationship(back_populates="api_keys")
+
+
+class Agent(Base):
+    __tablename__ = "agents"
+    __table_args__ = (
+        UniqueConstraint("org_id", "name"),
+        UniqueConstraint("org_id", "slug"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    org_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("organizations.id"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(nullable=False)
+    slug: Mapped[str] = mapped_column(nullable=False)
+    dir_path: Mapped[str] = mapped_column(nullable=False)
+    adapter_type: Mapped[str] = mapped_column(nullable=False)
+    adapter_config: Mapped[dict] = mapped_column(JSON, default=dict)
+    skills: Mapped[list] = mapped_column(JSON, default=list)
+    status: Mapped[str] = mapped_column(default="active")
+    heartbeat_interval_seconds: Mapped[int] = mapped_column(default=0)
+    last_heartbeat_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    created_at: Mapped[datetime] = mapped_column(default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        default=func.now(), onupdate=func.now()
+    )
+
+    organization: Mapped["Organization"] = relationship(back_populates="agents")

--- a/src/zenve/main.py
+++ b/src/zenve/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from zenve.api.lifespan import lifespan
-from zenve.api.routes import api_key_router, auth_router, core_router, org_router
+from zenve.api.routes import agent_router, api_key_router, auth_router, core_router, org_router
 
 app = FastAPI(lifespan=lifespan)
 
@@ -26,6 +26,7 @@ app.include_router(core_router)
 app.include_router(auth_router)
 app.include_router(org_router)
 app.include_router(api_key_router)
+app.include_router(agent_router)
 
 
 def main():

--- a/src/zenve/models/agent.py
+++ b/src/zenve/models/agent.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+KNOWN_ADAPTER_TYPES = ["claude_code", "codex", "anthropic_api"]
+
+
+class AgentCreate(BaseModel):
+    name: str
+    adapter_type: str
+    adapter_config: dict = {}
+    skills: list[str] = []
+    heartbeat_interval_seconds: int = 0
+    template: str = "default"
+    role: str | None = None
+
+
+class AgentUpdate(BaseModel):
+    name: str | None = None
+    adapter_config: dict | None = None
+    skills: list[str] | None = None
+    status: str | None = None
+    heartbeat_interval_seconds: int | None = None
+
+
+class AgentResponse(BaseModel):
+    id: str
+    org_id: str
+    name: str
+    slug: str
+    dir_path: str
+    adapter_type: str
+    adapter_config: dict
+    skills: list[str]
+    status: str
+    heartbeat_interval_seconds: int
+    last_heartbeat_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class AgentFileList(BaseModel):
+    files: list[str]
+
+
+class AgentFileContent(BaseModel):
+    path: str
+    content: str

--- a/src/zenve/services/__init__.py
+++ b/src/zenve/services/__init__.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 
 from zenve.config.settings import Settings, get_settings
 from zenve.db.database import get_db
+from zenve.services.agent import AgentService
 from zenve.services.api_key import ApiKeyService
 from zenve.services.auth import AuthService
 from zenve.services.filesystem import FilesystemService
@@ -23,3 +24,10 @@ def get_api_key_service(db: Session = Depends(get_db)) -> ApiKeyService:
 
 def get_filesystem_service(settings: Settings = Depends(get_settings)) -> FilesystemService:
     return FilesystemService(settings)
+
+
+def get_agent_service(
+    db: Session = Depends(get_db),
+    filesystem: FilesystemService = Depends(get_filesystem_service),
+) -> AgentService:
+    return AgentService(db, filesystem)

--- a/src/zenve/services/agent.py
+++ b/src/zenve/services/agent.py
@@ -1,0 +1,191 @@
+import re
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from zenve.config.settings import settings
+from zenve.db.models import Agent, Organization
+from zenve.models.agent import AgentCreate, AgentUpdate, KNOWN_ADAPTER_TYPES
+from zenve.services.filesystem import FilesystemService
+
+
+def _slugify(name: str) -> str:
+    slug = name.lower().strip()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    return slug.strip("-")
+
+
+class AgentService:
+    def __init__(self, db: Session, filesystem: FilesystemService):
+        self.db = db
+        self.filesystem = filesystem
+
+    def create(self, org: Organization, data: AgentCreate) -> Agent:
+        if data.adapter_type not in KNOWN_ADAPTER_TYPES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Unknown adapter_type '{data.adapter_type}'. Must be one of {KNOWN_ADAPTER_TYPES}",
+            )
+
+        slug = _slugify(data.name)
+        created_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+        template_vars = {
+            "agent_name": data.name,
+            "agent_slug": slug,
+            "org_name": org.name,
+            "org_slug": org.slug,
+            "role": data.role,
+            "adapter_type": data.adapter_type,
+            "gateway_url": settings.gateway_url,
+            "created_at": created_at,
+        }
+
+        dir_path = self.filesystem.scaffold_agent_dir(
+            org_slug=org.slug,
+            agent_slug=slug,
+            base_path=org.base_path,
+            template_vars=template_vars,
+            template_name=data.template,
+        )
+
+        agent_id = str(uuid.uuid4())
+
+        self.filesystem.write_gateway_json(
+            dir_path,
+            {
+                "id": agent_id,
+                "slug": slug,
+                "org_id": org.id,
+                "org_slug": org.slug,
+                "adapter_type": data.adapter_type,
+                "skills": data.skills,
+                "status": "active",
+                "heartbeat_interval_seconds": data.heartbeat_interval_seconds,
+                "gateway_url": settings.gateway_url,
+                "created_at": created_at,
+            },
+        )
+
+        agent = Agent(
+            id=agent_id,
+            org_id=org.id,
+            name=data.name,
+            slug=slug,
+            dir_path=dir_path,
+            adapter_type=data.adapter_type,
+            adapter_config=data.adapter_config,
+            skills=data.skills,
+            status="active",
+            heartbeat_interval_seconds=data.heartbeat_interval_seconds,
+        )
+        self.db.add(agent)
+        try:
+            self.db.commit()
+        except IntegrityError as exc:
+            self.db.rollback()
+            raise HTTPException(
+                status_code=409,
+                detail="An agent with this name or slug already exists in this organization",
+            ) from exc
+        self.db.refresh(agent)
+        return agent
+
+    def get_by_id(self, org_id: str, agent_id: str) -> Agent:
+        agent = (
+            self.db.query(Agent)
+            .filter(Agent.org_id == org_id, Agent.id == agent_id)
+            .first()
+        )
+        if not agent:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        return agent
+
+    def get_by_slug(self, org_id: str, slug: str) -> Agent:
+        agent = (
+            self.db.query(Agent)
+            .filter(Agent.org_id == org_id, Agent.slug == slug)
+            .first()
+        )
+        if not agent:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        return agent
+
+    def get_by_id_or_slug(self, org_id: str, identifier: str) -> Agent:
+        try:
+            uuid.UUID(identifier)
+            return self.get_by_id(org_id, identifier)
+        except ValueError:
+            return self.get_by_slug(org_id, identifier)
+
+    def list_by_org(
+        self,
+        org_id: str,
+        status: str | None = None,
+        adapter_type: str | None = None,
+    ) -> list[Agent]:
+        q = self.db.query(Agent).filter(Agent.org_id == org_id)
+        if status:
+            q = q.filter(Agent.status == status)
+        if adapter_type:
+            q = q.filter(Agent.adapter_type == adapter_type)
+        return q.all()
+
+    def update(self, org_id: str, agent_id: str, data: AgentUpdate) -> Agent:
+        agent = self.get_by_id(org_id, agent_id)
+
+        gateway_dirty = False
+
+        if data.name is not None:
+            agent.name = data.name
+        if data.adapter_config is not None:
+            agent.adapter_config = data.adapter_config
+            gateway_dirty = True
+        if data.skills is not None:
+            agent.skills = data.skills
+            gateway_dirty = True
+        if data.status is not None:
+            agent.status = data.status
+            gateway_dirty = True
+        if data.heartbeat_interval_seconds is not None:
+            agent.heartbeat_interval_seconds = data.heartbeat_interval_seconds
+            gateway_dirty = True
+
+        self.db.commit()
+        self.db.refresh(agent)
+
+        if gateway_dirty:
+            gw = self.filesystem.read_gateway_json(agent.dir_path)
+            if data.skills is not None:
+                gw["skills"] = agent.skills
+            if data.status is not None:
+                gw["status"] = agent.status
+            if data.heartbeat_interval_seconds is not None:
+                gw["heartbeat_interval_seconds"] = agent.heartbeat_interval_seconds
+            self.filesystem.write_gateway_json(agent.dir_path, gw)
+
+        return agent
+
+    def archive(self, org_id: str, agent_id: str) -> Agent:
+        agent = self.get_by_id(org_id, agent_id)
+        agent.status = "archived"
+        self.db.commit()
+        self.db.refresh(agent)
+
+        gw = self.filesystem.read_gateway_json(agent.dir_path)
+        gw["status"] = "archived"
+        self.filesystem.write_gateway_json(agent.dir_path, gw)
+
+        return agent
+
+    def get_agent_files(self, agent: Agent) -> list[str]:
+        return self.filesystem.list_agent_files(agent.dir_path)
+
+    def read_agent_file(self, agent: Agent, path: str) -> str:
+        return self.filesystem.read_agent_file(agent.dir_path, path)
+
+    def write_agent_file(self, agent: Agent, path: str, content: str) -> None:
+        self.filesystem.write_agent_file(agent.dir_path, path, content)


### PR DESCRIPTION
## Summary

- **Agent ORM model** (`db/models.py`) — `agents` table with JSON `adapter_config`/`skills` columns, unique constraints on `(org_id, name)` and `(org_id, slug)`, FK relationship to `organizations`
- **Pydantic models** (`models/agent.py`) — `AgentCreate`, `AgentUpdate`, `AgentResponse`, `AgentFileList`, `AgentFileContent`; `KNOWN_ADAPTER_TYPES = ["claude_code", "codex", "anthropic_api"]`
- **AgentService** (`services/agent.py`) — create (scaffolds agent dir via `FilesystemService` + writes `gateway.json`), get by UUID or slug, list with `?status` / `?adapter_type` filters, update (syncs changed fields to `gateway.json`), archive (soft delete, keeps files), file list/read/write
- **Dependency function** (`services/__init__.py`) — `get_agent_service(db, filesystem)`
- **Routes** (`api/routes/agent.py`) — 8 endpoints, all scope-gated via `require_scope`:

| Method | Path | Scope |
|--------|------|-------|
| POST | `/api/v1/agents` | `agents:write` |
| GET | `/api/v1/agents` | `agents:read` |
| GET | `/api/v1/agents/{agent_id}` | `agents:read` |
| PATCH | `/api/v1/agents/{agent_id}` | `agents:write` |
| DELETE | `/api/v1/agents/{agent_id}` | `agents:write` |
| GET | `/api/v1/agents/{agent_id}/files` | `agents:read` |
| GET | `/api/v1/agents/{agent_id}/files/{path}` | `agents:read` |
| PUT | `/api/v1/agents/{agent_id}/files/{path}` | `agents:write` |

- **Router registration** — `api/routes/__init__.py` + `main.py`
- **Arch docs** — chunk 04 fully reconciled against chunks 02 & 03; overview updated to `designed`

## Test plan

- [ ] `POST /api/v1/orgs` → get API key
- [ ] `POST /api/v1/agents` with valid `adapter_type` → 201, agent dir + `gateway.json` created on disk
- [ ] `POST /api/v1/agents` with unknown `adapter_type` → 422
- [ ] `POST /api/v1/agents` with duplicate name in same org → 409
- [ ] `GET /api/v1/agents` → list; filter by `?status=active` and `?adapter_type=claude_code`
- [ ] `GET /api/v1/agents/{id}` and `GET /api/v1/agents/{slug}` → both resolve
- [ ] `PATCH /api/v1/agents/{id}` updating `skills`/`status` → `gateway.json` reflects change
- [ ] `DELETE /api/v1/agents/{id}` → status `archived`, files still on disk
- [ ] `GET /api/v1/agents/{id}/files` → lists scaffolded files
- [ ] `GET /api/v1/agents/{id}/files/SOUL.md` → returns content
- [ ] `PUT /api/v1/agents/{id}/files/memory/long_term.md` → updates file
- [ ] Path traversal attempt (e.g. `../../etc/passwd`) → rejected by `FilesystemService`
- [ ] Request with key missing `agents:write` scope → 403

https://claude.ai/code/session_01MZaEFtTNsSheL2u1f4VKLo