### PR TITLE
Add adapter interface: BaseAdapter ABC, AdapterRegistry, ClaudeCodeAdapter

### DIFF
--- a/agents/architect/docs/05-adapter-interface.md
+++ b/agents/architect/docs/05-adapter-interface.md
@@ -10,6 +10,33 @@ Define the BaseAdapter ABC, RunContext/RunResult dataclasses, and the AdapterReg
 
 ### 1. Data Models — `models/adapter.py`
 
+#### Typed Adapter Config Models
+
+```python
+from pydantic import BaseModel
+
+class AdapterConfigBase(BaseModel):
+    """Base class for all adapter config models."""
+    model_config = {"extra": "allow"}
+
+class ClaudeCodeConfig(AdapterConfigBase):
+    model: str | None = None            # optional, default: CLI default
+    max_tokens: int | None = None       # optional
+    allowed_tools: list[str] | None = None  # optional, restrict tools
+    max_turns: int | None = None        # optional
+
+class CodexConfig(AdapterConfigBase):
+    model: str | None = None            # optional
+    max_tokens: int | None = None       # optional
+
+class AnthropicAPIConfig(AdapterConfigBase):
+    model: str = "claude-sonnet-4-6"   # required, defaulted
+    max_tokens: int = 4096             # required, defaulted
+    api_key_env_var: str = "ANTHROPIC_API_KEY"  # env var name for API key
+```
+
+#### RunContext and RunResult
+
 ```python
 from dataclasses import dataclass
 
@@ -22,9 +49,10 @@ class RunContext:
     org_id: str
     org_slug: str
     run_id: str
+    adapter_type: str           # e.g. "claude_code", "codex"
     message: str | None         # user message for manual runs
     heartbeat: bool             # True if triggered by heartbeat
-    adapter_config: dict        # adapter-specific config from DB
+    adapter_config: dict        # adapter-specific config from DB (merged with defaults)
     gateway_url: str            # injected as env var
     agent_token: str            # short-lived JWT (Chunk 09, empty string for now)
     env_vars: dict              # extra env vars to pass
@@ -43,8 +71,27 @@ class RunResult:
 
 ```python
 from abc import ABC, abstractmethod
+from typing import ClassVar
 
 class BaseAdapter(ABC):
+
+    adapter_type: ClassVar[str]  # concrete subclasses declare this (e.g. "claude_code")
+
+    def name(self) -> str:
+        """Adapter identifier — reads adapter_type class variable."""
+        return self.adapter_type
+
+    @classmethod
+    @abstractmethod
+    def get_default_config(cls) -> AdapterConfigBase:
+        """Return a default config instance for this adapter type."""
+        ...
+
+    @classmethod
+    @abstractmethod
+    def validate_config(cls, raw_config: dict) -> AdapterConfigBase:
+        """Validate and coerce raw adapter_config dict into the typed config model."""
+        ...
 
     @abstractmethod
     async def execute(self, ctx: RunContext) -> RunResult:
@@ -54,11 +101,6 @@ class BaseAdapter(ABC):
     @abstractmethod
     async def health_check(self) -> bool:
         """Check if the runtime is available (e.g., CLI installed)."""
-        ...
-
-    @abstractmethod
-    def name(self) -> str:
-        """Adapter identifier (e.g. 'claude_code')."""
         ...
 ```
 
@@ -78,6 +120,14 @@ class AdapterRegistry:
         if adapter_type not in self._adapters:
             raise ValueError(f"Unknown adapter: {adapter_type}")
         return self._adapters[adapter_type]
+
+    def has(self, adapter_type: str) -> bool:
+        """Return True if adapter_type is registered."""
+        return adapter_type in self._adapters
+
+    def known_types(self) -> list[str]:
+        """Return sorted list of all registered adapter type strings."""
+        return sorted(self._adapters.keys())
 
     def list_adapters(self) -> list[str]:
         return list(self._adapters.keys())
@@ -103,10 +153,20 @@ Store on `app.state.adapter_registry` for access in routes/services.
 
 ### 5. RunContext Builder — `services/run_context.py`
 
+`adapter_type` is passed in from the caller (resolved from `agent.adapter_type` in the DB). `adapter_config` is expected to be the already-merged config (defaults + stored overrides) by the time this builder is called.
+
 ```python
-def build_run_context(agent: Agent, run: Run, message: str | None = None) -> RunContext:
+def build_run_context(
+    agent: Agent,
+    run: Run,
+    adapter_registry: AdapterRegistry,
+    message: str | None = None,
+) -> RunContext:
     """Build a RunContext from DB models. Used by Celery tasks."""
     org = agent.organization
+    adapter = adapter_registry.get(agent.adapter_type)
+    default_cfg = adapter.get_default_config().model_dump()
+    merged_cfg = {**default_cfg, **(agent.adapter_config or {})}
     return RunContext(
         agent_dir=agent.dir_path,
         agent_id=str(agent.id),
@@ -115,13 +175,48 @@ def build_run_context(agent: Agent, run: Run, message: str | None = None) -> Run
         org_id=str(org.id),
         org_slug=org.slug,
         run_id=str(run.id),
+        adapter_type=agent.adapter_type,
         message=message or run.message,
         heartbeat=(run.trigger == "heartbeat"),
-        adapter_config=agent.adapter_config or {},
+        adapter_config=merged_cfg,
         gateway_url=settings.GATEWAY_URL,
         agent_token="",  # Populated in Chunk 09
         env_vars={},
     )
+```
+
+### 6. AgentService Integration — `services/agent.py`
+
+`AgentService.__init__` accepts a third parameter `adapter_registry: AdapterRegistry`. The previous hard-coded `KNOWN_ADAPTER_TYPES` list check is replaced with registry-based validation. Default config is merged at agent-create time so stored `adapter_config` only contains user overrides.
+
+```python
+class AgentService:
+    def __init__(self, db: Session, filesystem: FilesystemService, adapter_registry: AdapterRegistry):
+        self.db = db
+        self.filesystem = filesystem
+        self.registry = adapter_registry
+
+    def create_agent(self, org: Organization, data: AgentCreate) -> Agent:
+        if not self.registry.has(data.adapter_type):
+            raise ValueError(
+                f"Unknown adapter type '{data.adapter_type}'. "
+                f"Known types: {self.registry.known_types()}"
+            )
+        # Merge defaults with user-supplied config; store only what was supplied
+        adapter = self.registry.get(data.adapter_type)
+        adapter.validate_config(data.adapter_config or {})  # raises on invalid fields
+        ...
+```
+
+The dependency function in `services/__init__.py` injects the registry from `app.state`:
+
+```python
+def get_agent_service(
+    request: Request,
+    db: Session = Depends(get_db),
+    filesystem: FilesystemService = Depends(get_filesystem_service),
+) -> AgentService:
+    return AgentService(db, filesystem, request.app.state.adapter_registry)
 ```
 
 ## Notes
@@ -129,3 +224,17 @@ def build_run_context(agent: Agent, run: Run, message: str | None = None) -> Run
 - `agents/` directory is used for adapters, not for agent CRUD logic (that's in `services/`).
 - The registry is a singleton created at startup and passed via app state or dependency injection.
 - `agent_token` is an empty string placeholder until Chunk 09 (Agent Runtime Tokens).
+- `adapter_type` on `RunContext` is redundant with `adapter_config` contents but kept for clarity — Celery tasks resolve the adapter by type before building context.
+- `validate_config()` raises a `ValidationError` (Pydantic) on invalid input; callers should catch and surface as HTTP 422.
+
+## Change Log
+
+| Date       | Change                                                                                     |
+|------------|--------------------------------------------------------------------------------------------|
+| 2026-04-06 | Added `adapter_type: ClassVar[str]` to `BaseAdapter`; `name()` made concrete               |
+| 2026-04-06 | Added `get_default_config()` and `validate_config()` abstract classmethods to `BaseAdapter` |
+| 2026-04-06 | Added `has()` and `known_types()` to `AdapterRegistry`                                     |
+| 2026-04-06 | Added typed config models: `AdapterConfigBase`, `ClaudeCodeConfig`, `CodexConfig`, `AnthropicAPIConfig` |
+| 2026-04-06 | Added `adapter_type: str` field to `RunContext`                                            |
+| 2026-04-06 | Updated `RunContext` builder to accept `adapter_registry` and merge default config          |
+| 2026-04-06 | Added `AgentService` integration section: registry param, `has()`/`known_types()` validation, dependency function |

--- a/agents/architect/docs/06-claude-code-adapter.md
+++ b/agents/architect/docs/06-claude-code-adapter.md
@@ -13,8 +13,17 @@ Implement the first concrete adapter: ClaudeCodeAdapter, which spawns the `claud
 ```python
 class ClaudeCodeAdapter(BaseAdapter):
 
-    def name(self) -> str:
-        return "claude_code"
+    adapter_type: ClassVar[str] = "claude_code"
+
+    @classmethod
+    def get_default_config(cls) -> ClaudeCodeConfig:
+        """Return a ClaudeCodeConfig with all defaults."""
+        return ClaudeCodeConfig()
+
+    @classmethod
+    def validate_config(cls, raw_config: dict) -> ClaudeCodeConfig:
+        """Validate and coerce raw adapter_config dict into ClaudeCodeConfig."""
+        return ClaudeCodeConfig.model_validate(raw_config)
 
     async def health_check(self) -> bool:
         """Check if `claude` CLI is installed and accessible."""
@@ -84,8 +93,11 @@ class ClaudeCodeAdapter(BaseAdapter):
 
 ### 2. CLI Args Builder
 
+`adapter_config` in `RunContext` is already merged (defaults + overrides) and validated as a `ClaudeCodeConfig` dict.
+
 ```python
 def _build_cli_args(self, ctx: RunContext, message: str, system_prompt: str) -> list[str]:
+    cfg = ClaudeCodeConfig.model_validate(ctx.adapter_config)
     args = ["claude"]
 
     # Non-interactive mode
@@ -97,13 +109,21 @@ def _build_cli_args(self, ctx: RunContext, message: str, system_prompt: str) -> 
     # System prompt (SOUL.md content)
     args.extend(["--system-prompt", system_prompt])
 
-    # Model override from adapter_config
-    if model := ctx.adapter_config.get("model"):
-        args.extend(["--model", model])
+    # Model override
+    if cfg.model:
+        args.extend(["--model", cfg.model])
 
-    # Max tokens from adapter_config
-    if max_tokens := ctx.adapter_config.get("max_tokens"):
-        args.extend(["--max-tokens", str(max_tokens)])
+    # Max tokens
+    if cfg.max_tokens:
+        args.extend(["--max-tokens", str(cfg.max_tokens)])
+
+    # Max turns
+    if cfg.max_turns:
+        args.extend(["--max-turns", str(cfg.max_turns)])
+
+    # Allowed tools
+    if cfg.allowed_tools:
+        args.extend(["--allowedTools", ",".join(cfg.allowed_tools)])
 
     # Output format
     args.extend(["--output-format", "json"])
@@ -132,14 +152,22 @@ adapter_registry.register(ClaudeCodeAdapter())
 
 ### 5. Adapter Config Schema
 
-Document expected `adapter_config` fields for Claude Code:
+Typed by `ClaudeCodeConfig` (defined in `models/adapter.py`). All fields are optional with `None` defaults — missing fields mean "use CLI default".
+
+| Field           | Type             | Default | Description                          |
+|-----------------|------------------|---------|--------------------------------------|
+| `model`         | `str \| None`    | `None`  | Model override (e.g. `claude-sonnet-4-6`) |
+| `max_tokens`    | `int \| None`    | `None`  | Max output tokens                    |
+| `allowed_tools` | `list[str] \| None` | `None` | Restrict tool access               |
+| `max_turns`     | `int \| None`    | `None`  | Max agentic turns                    |
+
+Example stored `adapter_config` (only overrides, not full defaults):
 
 ```json
 {
-  "model": "claude-sonnet-4-6",         // optional, default: CLI default
-  "max_tokens": 4096,                    // optional
-  "allowed_tools": ["Read", "Write"],    // optional, restrict tools
-  "max_turns": 10                        // optional
+  "model": "claude-sonnet-4-6",
+  "allowed_tools": ["Read", "Write"],
+  "max_turns": 10
 }
 ```
 
@@ -149,4 +177,16 @@ Document expected `adapter_config` fields for Claude Code:
 - Gateway env vars are injected so the agent can discover the gateway at runtime.
 - `--print` flag (or equivalent) ensures non-interactive execution.
 - Token usage parsing depends on Claude CLI output format — may need adjustment.
+- `adapter_type = "claude_code"` class variable drives `name()` via `BaseAdapter`.
+- `validate_config()` raises `pydantic.ValidationError` on unknown or invalid fields; callers surface as HTTP 422.
 - Future: support `--resume` for session persistence across heartbeats (Open Question #1).
+
+## Change Log
+
+| Date       | Change                                                                                          |
+|------------|-------------------------------------------------------------------------------------------------|
+| 2026-04-06 | Added `adapter_type: ClassVar[str] = "claude_code"` class variable                             |
+| 2026-04-06 | Added `get_default_config()` classmethod returning `ClaudeCodeConfig()`                        |
+| 2026-04-06 | Added `validate_config()` classmethod returning `ClaudeCodeConfig.model_validate(raw_config)`  |
+| 2026-04-06 | Updated CLI args builder to use typed `ClaudeCodeConfig` (added `max_turns`, `allowed_tools`)  |
+| 2026-04-06 | Replaced JSON schema block with typed `ClaudeCodeConfig` field table referencing `models/adapter.py` |

--- a/src/zenve/agents/__init__.py
+++ b/src/zenve/agents/__init__.py
@@ -1,1 +1,4 @@
+from zenve.agents.base import BaseAdapter
+from zenve.agents.registry import AdapterRegistry
 
+__all__ = ["AdapterRegistry", "BaseAdapter"]

--- a/src/zenve/agents/base.py
+++ b/src/zenve/agents/base.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import ClassVar
+
+from zenve.models.adapter import AdapterConfigBase, RunContext, RunResult
+
+
+class BaseAdapter(ABC):
+    """Contract that every agent runtime adapter must fulfill.
+
+    An adapter is stateless — it holds no per-run state. All execution
+    context is passed in via RunContext. A single adapter instance is
+    created at startup and reused for all runs of that adapter_type.
+    """
+
+    adapter_type: ClassVar[str]
+
+    def name(self) -> str:
+        """Return the canonical adapter identifier string (e.g. 'claude_code')."""
+        return self.__class__.adapter_type
+
+    # ------------------------------------------------------------------
+    # Config lifecycle
+    # ------------------------------------------------------------------
+
+    @classmethod
+    @abstractmethod
+    def get_default_config(cls) -> AdapterConfigBase:
+        """Return a default config instance with sensible defaults.
+
+        Called by AgentService.create() when adapter_config is empty or partial.
+        The returned model is serialized and stored in Agent.adapter_config.
+        """
+        ...
+
+    @classmethod
+    @abstractmethod
+    def validate_config(cls, raw_config: dict) -> AdapterConfigBase:
+        """Validate and coerce raw adapter_config dict into the typed config model.
+
+        Called by AgentService.create() and AgentService.update() before
+        persisting adapter_config changes. Raises pydantic.ValidationError
+        if the config is structurally invalid.
+        """
+        ...
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    async def execute(self, ctx: RunContext) -> RunResult:
+        """Execute the agent for one run (manual or heartbeat).
+
+        Called inside a Celery worker. Implementations must handle both run
+        types by inspecting ctx.heartbeat.
+
+        Must NOT raise on non-zero subprocess exit codes — those are captured
+        in RunResult.exit_code. Only raise for infrastructure failures that
+        should trigger a Celery retry.
+        """
+        ...
+
+    # ------------------------------------------------------------------
+    # Health
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    async def health_check(self) -> bool:
+        """Return True if this adapter's runtime dependency is available.
+
+        Must never raise — return False on any failure.
+        """
+        ...

--- a/src/zenve/agents/claude_code.py
+++ b/src/zenve/agents/claude_code.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import asyncio
+import asyncio.subprocess
+import json
+import os
+import time
+from pathlib import Path
+from typing import ClassVar
+
+from zenve.agents.base import BaseAdapter
+from zenve.models.adapter import ClaudeCodeConfig, RunContext, RunResult
+
+
+class ClaudeCodeAdapter(BaseAdapter):
+    """Adapter that spawns the `claude` CLI as a subprocess."""
+
+    adapter_type: ClassVar[str] = "claude_code"
+
+    # ------------------------------------------------------------------
+    # Config lifecycle
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def get_default_config(cls) -> ClaudeCodeConfig:
+        return ClaudeCodeConfig()
+
+    @classmethod
+    def validate_config(cls, raw_config: dict) -> ClaudeCodeConfig:
+        return ClaudeCodeConfig.model_validate(raw_config)
+
+    # ------------------------------------------------------------------
+    # Health
+    # ------------------------------------------------------------------
+
+    async def health_check(self) -> bool:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "claude", "--version",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await proc.communicate()
+            return proc.returncode == 0
+        except (FileNotFoundError, OSError):
+            return False
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    async def execute(self, ctx: RunContext) -> RunResult:
+        start = time.monotonic()
+        config = self.validate_config(ctx.adapter_config)
+
+        soul = self._read_file(Path(ctx.agent_dir) / "SOUL.md")
+        agents_md = self._read_file(Path(ctx.agent_dir) / "AGENTS.md")
+
+        if ctx.heartbeat:
+            heartbeat_md = self._read_file(Path(ctx.agent_dir) / "HEARTBEAT.md")
+            message = f"{agents_md}\n\n---\n\nHeartbeat tick. Review your checklist:\n\n{heartbeat_md}"
+        else:
+            message = f"{agents_md}\n\n---\n\n{ctx.message or '(no message provided)'}"
+
+        env = {
+            **os.environ,
+            "GATEWAY_URL": ctx.gateway_url,
+            "GATEWAY_AGENT_TOKEN": ctx.agent_token,
+            "GATEWAY_AGENT_ID": ctx.agent_id,
+            "GATEWAY_AGENT_SLUG": ctx.agent_slug,
+            "GATEWAY_ORG_SLUG": ctx.org_slug,
+            "GATEWAY_RUN_ID": ctx.run_id,
+            **ctx.env_vars,
+        }
+
+        args = self._build_cli_args(config, message, soul)
+
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            cwd=ctx.agent_dir,
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_bytes, stderr_bytes = await proc.communicate()
+
+        duration = time.monotonic() - start
+        stdout = stdout_bytes.decode(errors="replace")
+        stderr = stderr_bytes.decode(errors="replace")
+
+        token_usage = self._parse_token_usage(stdout)
+
+        return RunResult(
+            exit_code=proc.returncode or 0,
+            stdout=stdout,
+            stderr=stderr,
+            duration_seconds=duration,
+            token_usage=token_usage,
+            error=stderr if proc.returncode != 0 else None,
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _build_cli_args(
+        self, config: ClaudeCodeConfig, message: str, system_prompt: str
+    ) -> list[str]:
+        args = ["claude", "--print", "--output-format", config.output_format]
+        args.extend(["--system-prompt", system_prompt])
+        args.extend(["--prompt", message])
+        if config.model:
+            args.extend(["--model", config.model])
+        if config.max_tokens is not None:
+            args.extend(["--max-tokens", str(config.max_tokens)])
+        if config.max_turns:
+            args.extend(["--max-turns", str(config.max_turns)])
+        if config.allowed_tools:
+            for tool in config.allowed_tools:
+                args.extend(["--allowedTools", tool])
+        return args
+
+    def _parse_token_usage(self, stdout: str) -> dict | None:
+        """Parse token usage from Claude CLI JSON output.
+
+        The claude CLI with --output-format json wraps its response in a
+        JSON object. Returns None if parsing fails.
+        """
+        try:
+            data = json.loads(stdout)
+            usage = data.get("usage") or data.get("token_usage")
+            if isinstance(usage, dict):
+                return {
+                    "input_tokens": usage.get("input_tokens", 0),
+                    "output_tokens": usage.get("output_tokens", 0),
+                    "cost_usd": usage.get("cost_usd"),
+                }
+        except (json.JSONDecodeError, AttributeError):
+            pass
+        return None
+
+    @staticmethod
+    def _read_file(path: Path) -> str:
+        if path.exists():
+            return path.read_text(encoding="utf-8")
+        return f"(file not found: {path.name})"

--- a/src/zenve/agents/registry.py
+++ b/src/zenve/agents/registry.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+
+from zenve.agents.base import BaseAdapter
+
+
+class AdapterRegistry:
+    """Maps adapter_type strings to stateless BaseAdapter instances.
+
+    Created once in api/lifespan.py and stored on app.state.adapter_registry.
+    Replaces the KNOWN_ADAPTER_TYPES constant.
+
+    Usage:
+        registry = AdapterRegistry()
+        registry.register(ClaudeCodeAdapter())
+        adapter = registry.get("claude_code")
+        result = await adapter.execute(ctx)
+    """
+
+    def __init__(self) -> None:
+        self._adapters: dict[str, BaseAdapter] = {}
+
+    def register(self, adapter: BaseAdapter) -> None:
+        """Register an adapter instance under its adapter_type key.
+
+        Raises ValueError if an adapter for that type is already registered.
+        """
+        key = adapter.name()
+        if key in self._adapters:
+            raise ValueError(f"Adapter already registered: {key!r}")
+        self._adapters[key] = adapter
+
+    def get(self, adapter_type: str) -> BaseAdapter:
+        """Return the registered adapter for the given type.
+
+        Raises KeyError if no adapter is registered for that type.
+        AgentService catches this and converts it to an HTTP 422.
+        """
+        if adapter_type not in self._adapters:
+            raise KeyError(f"Unknown adapter_type: {adapter_type!r}")
+        return self._adapters[adapter_type]
+
+    def has(self, adapter_type: str) -> bool:
+        """Return True if an adapter is registered for the given type."""
+        return adapter_type in self._adapters
+
+    def known_types(self) -> list[str]:
+        """Return sorted list of registered adapter_type strings."""
+        return sorted(self._adapters.keys())
+
+    async def health_check_all(self) -> dict[str, bool]:
+        """Run health_check() on every registered adapter concurrently.
+
+        Returns a dict mapping adapter_type → bool. Used by GET /health.
+        """
+        results = await asyncio.gather(
+            *[adapter.health_check() for adapter in self._adapters.values()],
+            return_exceptions=True,
+        )
+        return {
+            name: (result is True)
+            for name, result in zip(self._adapters.keys(), results)
+        }

--- a/src/zenve/api/lifespan.py
+++ b/src/zenve/api/lifespan.py
@@ -3,6 +3,8 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from sqlalchemy import text
 
+from zenve.agents.claude_code import ClaudeCodeAdapter
+from zenve.agents.registry import AdapterRegistry
 from zenve.config.settings import settings
 from zenve.db.database import Base, engine
 from zenve.services.filesystem import FilesystemService
@@ -28,6 +30,11 @@ async def lifespan(app: FastAPI):
 
     FilesystemService(settings).seed_default_templates()
     print("Agent templates seeded")
+
+    registry = AdapterRegistry()
+    registry.register(ClaudeCodeAdapter())
+    app.state.adapter_registry = registry
+    print(f"Adapter registry initialized: {registry.known_types()}")
 
     yield
 

--- a/src/zenve/models/adapter.py
+++ b/src/zenve/models/adapter.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from pydantic import BaseModel
+
+
+# ---------------------------------------------------------------------------
+# Base config
+# ---------------------------------------------------------------------------
+
+
+class AdapterConfigBase(BaseModel):
+    """Base class for all adapter-specific configuration models.
+
+    Stored as JSON in Agent.adapter_config. Each adapter defines its own
+    config class inheriting from this.
+    """
+
+    model_config = {"extra": "ignore"}
+
+
+# ---------------------------------------------------------------------------
+# Per-adapter config models
+# ---------------------------------------------------------------------------
+
+
+class ClaudeCodeConfig(AdapterConfigBase):
+    """Config for the claude_code adapter (spawns `claude` CLI)."""
+
+    model: str = "claude-sonnet-4-6"
+    max_tokens: int | None = None
+    allowed_tools: list[str] | None = None
+    max_turns: int = 10
+    output_format: str = "json"
+
+
+class CodexConfig(AdapterConfigBase):
+    """Config for the codex adapter (spawns `codex` CLI)."""
+
+    model: str = "o4-mini"
+    max_tokens: int | None = None
+    approval_mode: str = "suggest"
+
+
+class AnthropicAPIConfig(AdapterConfigBase):
+    """Config for the anthropic_api adapter (calls Anthropic API directly)."""
+
+    model: str = "claude-opus-4-5"
+    max_tokens: int = 4096
+    temperature: float = 1.0
+    system_prompt_override: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Run data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunContext:
+    """All context needed to execute one agent run.
+
+    Built by services/run_context.py:build_run_context() from Agent ORM model.
+    Passed directly into BaseAdapter.execute().
+    """
+
+    agent_dir: str
+    agent_id: str
+    agent_slug: str
+    agent_name: str
+    org_id: str
+    org_slug: str
+    run_id: str
+    adapter_type: str
+    adapter_config: dict
+    message: str | None
+    heartbeat: bool
+    gateway_url: str
+    agent_token: str  # short-lived JWT (Chunk 09); empty string until then
+    env_vars: dict = field(default_factory=dict)
+
+
+@dataclass
+class RunResult:
+    """Result of one completed agent run.
+
+    Returned by BaseAdapter.execute(). Stored in the Run ORM record and
+    written to disk as a transcript.
+    """
+
+    exit_code: int
+    stdout: str
+    stderr: str
+    duration_seconds: float
+    token_usage: dict | None = None  # {input_tokens, output_tokens, cost_usd}
+    error: str | None = None

--- a/src/zenve/models/agent.py
+++ b/src/zenve/models/agent.py
@@ -2,8 +2,6 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
-KNOWN_ADAPTER_TYPES = ["claude_code", "codex", "anthropic_api"]
-
 
 class AgentCreate(BaseModel):
     name: str

--- a/src/zenve/services/__init__.py
+++ b/src/zenve/services/__init__.py
@@ -1,6 +1,7 @@
-from fastapi import Depends
+from fastapi import Depends, Request
 from sqlalchemy.orm import Session
 
+from zenve.agents.registry import AdapterRegistry
 from zenve.config.settings import Settings, get_settings
 from zenve.db.database import get_db
 from zenve.services.agent import AgentService
@@ -26,8 +27,13 @@ def get_filesystem_service(settings: Settings = Depends(get_settings)) -> Filesy
     return FilesystemService(settings)
 
 
+def get_adapter_registry(request: Request) -> AdapterRegistry:
+    return request.app.state.adapter_registry
+
+
 def get_agent_service(
     db: Session = Depends(get_db),
     filesystem: FilesystemService = Depends(get_filesystem_service),
+    adapter_registry: AdapterRegistry = Depends(get_adapter_registry),
 ) -> AgentService:
-    return AgentService(db, filesystem)
+    return AgentService(db, filesystem, adapter_registry)

--- a/src/zenve/services/agent.py
+++ b/src/zenve/services/agent.py
@@ -7,8 +7,9 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from zenve.config.settings import settings
+from zenve.agents.registry import AdapterRegistry
 from zenve.db.models import Agent, Organization
-from zenve.models.agent import AgentCreate, AgentUpdate, KNOWN_ADAPTER_TYPES
+from zenve.models.agent import AgentCreate, AgentUpdate
 from zenve.services.filesystem import FilesystemService
 
 
@@ -19,16 +20,22 @@ def _slugify(name: str) -> str:
 
 
 class AgentService:
-    def __init__(self, db: Session, filesystem: FilesystemService):
+    def __init__(self, db: Session, filesystem: FilesystemService, adapter_registry: AdapterRegistry):
         self.db = db
         self.filesystem = filesystem
+        self.adapter_registry = adapter_registry
 
     def create(self, org: Organization, data: AgentCreate) -> Agent:
-        if data.adapter_type not in KNOWN_ADAPTER_TYPES:
+        if not self.adapter_registry.has(data.adapter_type):
             raise HTTPException(
                 status_code=422,
-                detail=f"Unknown adapter_type '{data.adapter_type}'. Must be one of {KNOWN_ADAPTER_TYPES}",
+                detail=f"Unknown adapter_type '{data.adapter_type}'. Known types: {self.adapter_registry.known_types()}",
             )
+
+        adapter = self.adapter_registry.get(data.adapter_type)
+        default_config = adapter.get_default_config().model_dump(exclude_none=True)
+        adapter_config = {**default_config, **data.adapter_config}
+        adapter.validate_config(adapter_config)
 
         slug = _slugify(data.name)
         created_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -77,7 +84,7 @@ class AgentService:
             slug=slug,
             dir_path=dir_path,
             adapter_type=data.adapter_type,
-            adapter_config=data.adapter_config,
+            adapter_config=adapter_config,
             skills=data.skills,
             status="active",
             heartbeat_interval_seconds=data.heartbeat_interval_seconds,

--- a/src/zenve/services/run_context.py
+++ b/src/zenve/services/run_context.py
@@ -1,0 +1,42 @@
+from zenve.config.settings import settings
+from zenve.db.models import Agent
+from zenve.models.adapter import RunContext
+
+
+def build_run_context(
+    agent: Agent,
+    run_id: str,
+    message: str | None = None,
+    heartbeat: bool = False,
+    agent_token: str = "",
+    extra_env: dict | None = None,
+) -> RunContext:
+    """Build a RunContext from an Agent ORM record.
+
+    Args:
+        agent:       Agent ORM instance. agent.organization must be loaded.
+        run_id:      UUID string of the Run being executed.
+        message:     The user prompt. None for heartbeat runs.
+        heartbeat:   True if this is a scheduled heartbeat tick.
+        agent_token: Short-lived JWT for agent callbacks (Chunk 09).
+        extra_env:   Additional environment variables to inject.
+
+    Returns:
+        RunContext ready to be passed into BaseAdapter.execute().
+    """
+    return RunContext(
+        agent_dir=agent.dir_path,
+        agent_id=agent.id,
+        agent_slug=agent.slug,
+        agent_name=agent.name,
+        org_id=agent.org_id,
+        org_slug=agent.organization.slug,
+        run_id=run_id,
+        adapter_type=agent.adapter_type,
+        adapter_config=agent.adapter_config or {},
+        message=message,
+        heartbeat=heartbeat,
+        gateway_url=settings.gateway_url,
+        agent_token=agent_token,
+        env_vars=extra_env or {},
+    )


### PR DESCRIPTION
Introduces a pluggable execution layer for agent runtimes:

- models/adapter.py: RunContext, RunResult dataclasses + typed config models
  (ClaudeCodeConfig, CodexConfig, AnthropicAPIConfig)
- agents/base.py: BaseAdapter ABC with execute, health_check, validate_config,
  get_default_config abstract methods
- agents/registry.py: AdapterRegistry replacing KNOWN_ADAPTER_TYPES list
- agents/claude_code.py: Full ClaudeCodeAdapter implementation (spawns claude CLI)
- services/run_context.py: build_run_context() helper bridging Agent ORM → RunContext
- api/lifespan.py: registry instantiated at startup, stored on app.state
- services/__init__.py: get_adapter_registry dep + updated get_agent_service
- services/agent.py: registry-based validation + default config merge on create
- agents/architect/docs: updated chunks 05 and 06 to reflect refined design

https://claude.ai/code/session_018ETfFbYTsovMSJN8dJPeeE