### PR TITLE
feat(ui): organization slug routing, org switcher, and loading states

### DIFF
--- a/.agents/skills/commit/README.md
+++ b/.agents/skills/commit/README.md
@@ -1,0 +1,53 @@
+# commit
+
+Claude Code skill for creating well-structured git commits using conventional commit format.
+
+## Install
+
+```bash
+npx skills add ghalex/skills --skill commit
+```
+
+## Usage
+
+```
+/commit
+```
+
+## What it does
+
+1. Runs `git status` and `git diff` to analyze all changes
+2. Groups files into logical commits by topic (UI, Redux, docs, config, etc.)
+3. Presents the grouping plan and **waits for your approval**
+4. Creates commits sequentially using conventional commit format
+5. Shows a final summary of all commits created
+
+## Commit format
+
+```
+type(scope): description
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`
+
+## Example output
+
+```
+Commit 1: feat(ui): add simple signup form
+- src/components/custom/simple-signup-form.tsx
+
+Commit 2: docs: update agent instructions
+- .agents/redux-agent.md
+- CLAUDE.md
+
+Commit 3: chore: add lint:file script
+- package.json
+
+Proceed with these commits? (yes/no)
+```
+
+## Rules
+
+- Never mixes unrelated files in one commit
+- Always asks for confirmation before committing
+- Never pushes unless explicitly asked

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: commit
+description: "Use this skill when the user asks to commit code, create a commit, or save changes to git"
+version: 1.0.0
+---
+
+You are about to create git commit(s). Follow these steps:
+
+1. **Check git status**:
+   - Run `git status` to see all unstaged and staged files
+   - Show me what files have changed
+
+2. **Review the changes**:
+   - Run `git diff` to see the actual changes in all modified files
+   - Analyze all changes to understand what was modified
+
+3. **Group files by related changes**:
+   - Analyze the changes and group files into logical commits
+   - Grouping criteria:
+     - Files that implement the same feature together
+     - UI components in one commit, Redux changes in another
+     - Documentation updates separate from code changes
+     - Configuration files (package.json, .md files) grouped by purpose
+     - Agent files (.agents/) grouped together if related
+   - Examples:
+     - Group 1: `simple-signup-form.tsx` (new UI component)
+     - Group 2: `CLAUDE.md`, `redux-agent.md`, `ui-agent.md` (documentation)
+     - Group 3: `package.json` (dependency or script changes)
+     - Group 4: `store/users/api.ts`, `store/users/slice.ts`, `store/users/index.ts` (Redux module)
+
+4. **Present the grouping plan**:
+   - Show me the proposed groups and ask for confirmation
+   - Format:
+     ```
+     Commit 1: feat(ui): add simple signup form
+     - src/components/custom/simple-signup-form.tsx
+
+     Commit 2: docs: add redux and ui agent instructions
+     - .agents/redux-agent.md
+     - .agents/ui-agent.md
+     - CLAUDE.md
+
+     Commit 3: chore: add lint:file script to package.json
+     - package.json
+     ```
+   - Wait for my approval or adjustments
+
+5. **Create commits sequentially**:
+   For each approved group:
+   - Run `git add <files>` for only the files in that group
+   - Create a meaningful commit message following conventional commit format:
+     - Format: `type(scope): description`
+     - Types: feat, fix, refactor, docs, style, test, chore
+     - Keep the first line under 72 characters
+   - Run `git commit -m "message"` with the generated message
+   - Run `git log -1` to confirm the commit
+
+6. **Final summary**:
+   - Run `git log -<n>` where n = number of commits created
+   - Show me all commits that were created
+
+**Conventional Commit Examples:**
+- `feat(ui): add simple signup form with Field components`
+- `feat(redux): add user preferences state management`
+- `fix(auth): prevent duplicate loading states in slices`
+- `docs: update CLAUDE.md with redux-agent instructions`
+- `docs(agents): add ui-agent workflow documentation`
+- `refactor(auth): improve token validation logic`
+- `chore: add lint:file script to package.json`
+- `style(ui): update button component spacing`
+
+**Important Rules:**
+- NEVER include unrelated files in the same commit
+- ALWAYS ask for confirmation before creating commits
+- DO NOT push to remote unless I explicitly ask you to
+- If there's only one logical group, create a single commit

--- a/.agents/skills/fastapi-architect/README.md
+++ b/.agents/skills/fastapi-architect/README.md
@@ -1,0 +1,50 @@
+# fastapi-architect
+
+Claude Code skill that audits any FastAPI project against a clean layered architecture.
+
+## Install
+
+```bash
+npx skills add ghalex/skills --skill fastapi-architect
+```
+
+## Usage
+
+Navigate to any FastAPI project and ask Claude:
+
+> "review my routes"
+> "check architecture"
+> "audit this project"
+> "does this follow the fastapi rules"
+> "review my code structure"
+
+## What it checks
+
+**Routes** — no business logic, no db queries, no inline dependency functions
+
+**Services** — business logic only here, `get_*_service` in `services/__init__.py`
+
+**Models** — Pydantic models outside `api/`, ORM models use SQLAlchemy 2.x `Mapped` style
+
+**Agents** — no direct db access, services injected via constructor
+
+**General** — CORS, uvicorn config, lifespan typing
+
+## Output
+
+```
+## Architecture Review
+
+### ✅ Passing
+- Models correctly placed in models/
+- ...
+
+### ❌ Violations
+#### src/myapi/api/routes/users.py
+- **Rule:** No db queries inside route handlers
+- **Found:** db.query(UserRecord)... called directly in route
+- **Fix:** Move to UserService.get_user() and inject via Depends(get_user_service)
+
+### Summary
+2 violations found in 1 file.
+```

--- a/.agents/skills/fastapi-architect/SKILL.md
+++ b/.agents/skills/fastapi-architect/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: fastapi-architect
+description: Audits a FastAPI project against architecture rules. Use when asked to "review routes", "check architecture", "audit this project", "does this follow fastapi rules", or "review my code structure".
+version: 1.1.0
+---
+
+# FastAPI Architect Review
+
+You are an architecture auditor for REST APIs written in Python using FastAPI. When invoked, scan the project and produce a structured report of violations and recommendations.
+
+---
+
+## Step 0: Detect Layout
+
+Before auditing, determine which layout the project uses:
+
+**Monorepo** — if any of these are true:
+- Root `pyproject.toml` contains `[tool.uv.workspace]`
+- An `apps/` directory and a `packages/` directory both exist at the root
+
+**Standalone** — otherwise (single `src/{project}/` layout)
+
+State the detected layout at the top of your report.
+
+---
+
+## Architecture Rules
+
+The rules are the same for both layouts. Only the **paths differ**.
+
+### Path Map
+
+| Concept | Standalone | Monorepo |
+|---|---|---|
+| Routes | `src/{project}/api/routes/` | `apps/*/src/api/routes/` |
+| Services | `src/{project}/services/` | `packages/services/src/{project}_services/` |
+| Models (Pydantic) | `src/{project}/models/` | `packages/models/src/{project}_models/` |
+| DB (ORM + session) | `src/{project}/db/` | `packages/db/src/{project}_db/` |
+| Utils | `src/{project}/utils/` | `packages/utils/src/{project}_utils/` |
+| Config | `src/{project}/config/` | `packages/config/src/{project}_config/` |
+| Main | `src/{project}/main.py` | `apps/*/src/api/main.py` |
+| Service deps | `services/__init__.py` | `{project}_services/__init__.py` |
+
+In a monorepo, also check:
+- [ ] Each `packages/*/pyproject.toml` only declares dependencies it actually needs (no over-importing)
+- [ ] Internal workspace deps use `{ workspace = true }` in `[tool.uv.sources]`, not pinned versions
+- [ ] Route files do NOT import directly from `{project}_db` — they go through services
+- [ ] The `packages/services/` package does not import from `apps/`
+
+---
+
+### Route Rules
+- [ ] No db queries inside route handlers
+- [ ] No business logic inside route handlers
+- [ ] Routes only call services via `Depends()`
+- [ ] `get_*_service` functions are NOT defined in route files
+- [ ] No direct db imports in route files (`from {project}.db` / `from {project}_db`)
+- [ ] No `Session` or `get_db` used directly in route handlers
+
+### Service Rules
+- [ ] All business logic lives in services
+- [ ] Services receive `db: Session` in `__init__`, never import `get_db` directly
+- [ ] Dependency functions (`get_*_service`) live in `services/__init__.py`
+
+### Model Rules
+- [ ] All Pydantic models are in the models layer, not inside `api/` or route files
+- [ ] ORM models use `Mapped` / `mapped_column` (SQLAlchemy 2.x style)
+- [ ] No `Column(Integer, ...)` legacy style
+
+### Agent Rules (if agents exist)
+- [ ] Agents do not import `db`, `Session`, or `get_db` directly
+- [ ] Agents receive services via constructor injection
+- [ ] Agents do not contain business logic — they delegate to services
+
+### General
+- [ ] `lifespan` function has `app: FastAPI` type annotation
+- [ ] CORS configured in `main.py`
+
+---
+
+## Review Process
+
+1. **Detect layout** (monorepo vs standalone) and state it
+2. **Scan structure** — confirm expected directories exist in the right places
+3. **Read each route file** — check for route rule violations
+4. **Read each service file** — check for service rule violations
+5. **Read the service `__init__.py`** — verify dependency functions are here only
+6. **Read model files** — check placement, check ORM style
+7. **Read agent files** (if any) — check they don't touch db directly
+8. **Read `main.py`** — check CORS, router registration
+9. **Monorepo only:** spot-check `pyproject.toml` files for correct workspace dep declarations
+
+---
+
+## Output Format
+
+```
+## Architecture Review
+**Layout detected:** Standalone | Monorepo
+
+### ✅ Passing
+- <list of rules that are correctly followed>
+
+### ❌ Violations
+#### <file path>
+- **Rule:** <rule that is violated>
+- **Found:** <what the code actually does>
+- **Fix:** <exact change needed>
+
+### ⚠️ Warnings
+- <things that are not violations but could be improved>
+
+### Summary
+X violations found in Y files.
+```
+
+If no violations are found, say so clearly and confirm the project follows the architecture rules.

--- a/.agents/skills/fastapi-monorepo-setup/README.md
+++ b/.agents/skills/fastapi-monorepo-setup/README.md
@@ -1,0 +1,58 @@
+# fastapi-monorepo-setup
+
+Scaffolds a production-ready FastAPI monorepo using `uv` workspaces.
+
+## What it creates
+
+Given a project name (e.g. `myapp`), scaffolds:
+
+```
+myapp/
+├── apps/api/          ← FastAPI app with JWT auth routes
+└── packages/
+    ├── config/        ← pydantic-settings (myapp-config)
+    ├── db/            ← SQLAlchemy engine + ORM models (myapp-db)
+    ├── models/        ← Pydantic request/response models (myapp-models)
+    ├── utils/         ← JWT, hashing, get_current_user (myapp-utils)
+    └── services/      ← Business logic (myapp-services)
+```
+
+## Trigger phrases
+
+- "create a new fastapi monorepo"
+- "setup a monorepo fastapi project"
+- "scaffold a fastapi monorepo"
+- "new fastapi project with packages"
+- "initialize a fastapi monorepo"
+- "add a new app to a fastapi monorepo"
+
+## Tech stack
+
+- **FastAPI** + **uvicorn**
+- **uv workspaces** (single `uv.lock` at root)
+- **SQLAlchemy 2** + SQLite (default) / PostgreSQL
+- **JWT** via `python-jose` + `bcrypt`
+- **Pydantic v2** + `pydantic-settings`
+- **Docker** with fast startup (`uv sync --package` + direct venv CMD)
+- **just** task runner
+
+## Package dependency chain
+
+```
+myapp-config  (no internal deps)
+myapp-db      → myapp-config
+myapp-models  → (pydantic only)
+myapp-utils   → myapp-config, myapp-db
+myapp-services → myapp-db, myapp-models, myapp-utils
+apps/api       → all packages above
+```
+
+## Quick start (after scaffolding)
+
+```bash
+uv sync
+cp .env.example .env
+just dev
+```
+
+API at `http://localhost:8000` — `POST /auth/signup` returns a JWT.

--- a/.agents/skills/fastapi-monorepo-setup/SKILL.md
+++ b/.agents/skills/fastapi-monorepo-setup/SKILL.md
@@ -1,0 +1,960 @@
+---
+name: fastapi-monorepo-setup
+description: Scaffolds a production-ready FastAPI monorepo with uv workspaces, 5 shared packages (config, db, models, utils, services), JWT auth, SQLAlchemy, and Docker support. Use when asked to "create a new fastapi monorepo", "setup a monorepo fastapi project", "scaffold a fastapi monorepo", "new fastapi project with packages", "initialize a fastapi monorepo", or "add a new app to a fastapi monorepo".
+version: 1.0.0
+---
+
+# FastAPI Monorepo Setup
+
+Scaffold a complete, production-ready FastAPI monorepo using `uv` workspaces. Ask the user for the **project name** if not provided (e.g. `myapp`). Use it throughout as `{project}`.
+
+- Package names use **hyphens**: `{project}-config`, `{project}-db`, etc.
+- Python module names use **underscores**: `{project}_config`, `{project}_db`, etc.
+
+---
+
+## Project Structure
+
+Create all files exactly as shown. Replace `{project}` with the actual project name.
+
+```
+{project}/
+├── apps/
+│   └── api/
+│       ├── src/api/
+│       │   ├── routes/
+│       │   │   ├── __init__.py
+│       │   │   ├── auth.py
+│       │   │   └── core.py
+│       │   ├── __init__.py
+│       │   ├── lifespan.py
+│       │   └── main.py
+│       ├── pyproject.toml
+│       └── Dockerfile
+├── packages/
+│   ├── config/
+│   │   ├── src/{project}_config/
+│   │   │   ├── __init__.py
+│   │   │   └── settings.py
+│   │   └── pyproject.toml
+│   ├── db/
+│   │   ├── src/{project}_db/
+│   │   │   ├── __init__.py
+│   │   │   ├── database.py
+│   │   │   └── models.py
+│   │   └── pyproject.toml
+│   ├── models/
+│   │   ├── src/{project}_models/
+│   │   │   ├── __init__.py
+│   │   │   └── auth.py
+│   │   └── pyproject.toml
+│   ├── services/
+│   │   ├── src/{project}_services/
+│   │   │   ├── __init__.py
+│   │   │   └── auth.py
+│   │   └── pyproject.toml
+│   └── utils/
+│       ├── src/{project}_utils/
+│       │   ├── __init__.py
+│       │   └── auth.py
+│       └── pyproject.toml
+├── pyproject.toml
+├── justfile
+├── docker-compose.yml
+├── CLAUDE.md
+├── .env.example
+└── .python-version
+```
+
+---
+
+## File Templates
+
+### `.python-version`
+```
+3.13
+```
+
+### `.env.example`
+```
+SECRET_KEY=changeme-use-a-long-random-string
+SQLITE_DATABASE_URL={project}.db
+PG_DATABASE_URL=postgresql://user:password@localhost:5432/{project}
+```
+
+### `pyproject.toml` (workspace root)
+```toml
+[project]
+name = "{project}-workspace"
+version = "0.1.0"
+description = "{project} monorepo workspace"
+requires-python = ">=3.13"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+only-include = ["README.md"]
+
+[tool.uv.workspace]
+members = [
+    "apps/api",
+    "packages/*",
+]
+
+[tool.uv.sources]
+{project}-config = { workspace = true }
+{project}-db = { workspace = true }
+{project}-models = { workspace = true }
+{project}-utils = { workspace = true }
+{project}-services = { workspace = true }
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.407",
+    "ruff>=0.11.0",
+]
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "UP", "B"]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = [
+    "{project}_config",
+    "{project}_db",
+    "{project}_models",
+    "{project}_utils",
+    "{project}_services",
+]
+```
+
+### `justfile`
+```just
+# Application
+
+dev:
+    API_RELOAD=true uv run api-start
+
+start:
+    uv run api-start
+
+# Package management
+
+install:
+    uv sync
+
+add-to-api package:
+    uv add --package {project}-api {{package}}
+
+add-to-pkg pkg package:
+    uv add --package {{pkg}} {{package}}
+
+update:
+    uv lock --upgrade
+    uv sync
+
+# Docker
+
+docker-build:
+    docker build -f apps/api/Dockerfile -t {project}-api:latest .
+
+docker-up:
+    docker compose up -d
+
+docker-down:
+    docker compose down
+
+docker-logs:
+    docker compose logs -f
+
+# Code quality
+
+format:
+    uv run ruff format .
+
+lint path=".":
+    uv run ruff check {{path}}
+
+lint-fix path=".":
+    uv run ruff check --fix {{path}}
+
+typecheck path=".":
+    uv run pyright {{path}}
+```
+
+### `docker-compose.yml`
+```yaml
+services:
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    image: {project}-api:latest
+    container_name: {project}-api
+    ports:
+      - "8000:8000"
+    restart: unless-stopped
+    environment:
+      - SECRET_KEY=${SECRET_KEY}
+      - SQLITE_DATABASE_URL=${SQLITE_DATABASE_URL}
+      - PG_DATABASE_URL=${PG_DATABASE_URL}
+```
+
+### `CLAUDE.md`
+```markdown
+# CLAUDE.md
+
+Architecture and development rules for this FastAPI monorepo.
+
+## Monorepo Structure
+
+\`\`\`
+{project}/
+├── apps/api/         # Deployable FastAPI application
+│   └── src/api/
+│       ├── routes/   # Thin HTTP handlers only
+│       ├── lifespan.py
+│       └── main.py
+└── packages/
+    ├── config/       # Settings (pydantic-settings)
+    ├── db/           # SQLAlchemy engine, session, ORM models
+    ├── models/       # Pydantic request/response models
+    ├── services/     # Business logic
+    └── utils/        # Stateless helpers (JWT, hashing, auth deps)
+\`\`\`
+
+## Layer Rules
+
+### Routes (`apps/api/src/api/routes/`)
+- Thin wrappers only — no business logic, no db queries
+- Only call services via `Depends()`
+- Import from `{project}_services`, never from `{project}_db` directly
+
+### Services (`packages/services/`)
+- All business logic lives here
+- Receive `db: Session` via constructor, never import `get_db` directly
+- Dependency functions (`get_*_service`) go in `{project}_services/__init__.py`
+
+### Models (`packages/models/`)
+- All Pydantic models go here — never define them inside `apps/api/`
+- Shared freely across routes, services, and utils
+
+### Utils (`packages/utils/`)
+- Pure stateless helpers: hashing, JWT, `get_current_user` FastAPI dependency
+- No business logic
+
+### DB (`packages/db/`)
+- `database.py` — engine, session, `get_db`
+- `models.py` — SQLAlchemy ORM models using `Mapped` / `mapped_column`
+- Only imported by `services/` and `utils/`
+
+## Package Dependency Chain
+
+\`\`\`
+{project}-config  (no internal deps)
+{project}-db      → {project}-config
+{project}-models  → (pydantic only)
+{project}-utils   → {project}-config, {project}-db
+{project}-services → {project}-db, {project}-models, {project}-utils
+apps/api          → all packages above
+\`\`\`
+
+## Violations to Flag
+
+- `from {project}_db` imported inside any `apps/api/routes/` file
+- `get_db` used directly in a route handler
+- Pydantic models defined inside `apps/api/`
+- Business logic (db queries, conditionals) inside route handlers
+
+## Development Commands
+
+\`\`\`bash
+just dev          # start with hot reload
+just start        # start production mode
+just lint         # ruff check
+just lint-fix     # ruff check --fix
+just format       # ruff format
+just typecheck    # pyright
+
+just docker-build # build image
+just docker-up    # start container
+just docker-down  # stop container
+just docker-logs  # tail logs
+\`\`\`
+
+## Adding a New Feature
+
+1. **Pydantic model** → `packages/models/src/{project}_models/{domain}.py`
+2. **ORM model** → `packages/db/src/{project}_db/models.py`
+3. **Service** → `packages/services/src/{project}_services/{domain}.py`
+4. **Dependency function** → `packages/services/src/{project}_services/__init__.py`
+5. **Route** → `apps/api/src/api/routes/{domain}.py` (thin wrapper)
+6. **Register router** → `apps/api/src/api/routes/__init__.py` + `main.py`
+
+## Adding a New Package
+
+1. Create `packages/{name}/pyproject.toml` with name `{project}-{name}`
+2. Create `packages/{name}/src/{project}_{name}/__init__.py`
+3. Add to workspace root `pyproject.toml`: `[tool.uv.sources]` entry
+4. Run `uv sync`
+```
+
+---
+
+## Package Templates
+
+### `packages/config/pyproject.toml`
+```toml
+[project]
+name = "{project}-config"
+version = "0.1.0"
+description = "{project} configuration package"
+requires-python = ">=3.13"
+dependencies = [
+    "pydantic>=2.10.0",
+    "pydantic-settings>=2.7.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/{project}_config"]
+```
+
+### `packages/config/src/{project}_config/__init__.py`
+```python
+from .settings import Settings, get_settings, settings
+
+__all__ = ["Settings", "get_settings", "settings"]
+```
+
+### `packages/config/src/{project}_config/settings.py`
+```python
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    secret_key: str
+    sqlite_database_url: str = "{project}.db"
+    pg_database_url: str | None = None
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    return Settings()
+
+
+settings = get_settings()
+```
+
+---
+
+### `packages/db/pyproject.toml`
+```toml
+[project]
+name = "{project}-db"
+version = "0.1.0"
+description = "{project} database models and connection"
+requires-python = ">=3.13"
+dependencies = [
+    "sqlalchemy>=2.0.0",
+    "psycopg2-binary>=2.9.0",
+    "{project}-config",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/{project}_db"]
+
+[tool.uv.sources]
+{project}-config = { workspace = true }
+```
+
+### `packages/db/src/{project}_db/__init__.py`
+```python
+from .database import Base, Session, engine, get_db
+from .models import UserRecord
+
+__all__ = ["Base", "Session", "engine", "get_db", "UserRecord"]
+```
+
+### `packages/db/src/{project}_db/database.py`
+```python
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+from {project}_config.settings import settings
+
+
+def create_sqlite_engine(path: str | None = None):
+    if path is None:
+        path = settings.sqlite_database_url
+    if not path:
+        raise ValueError("SQLITE_DATABASE_URL is not set.")
+    return create_engine(f"sqlite:///{path}")
+
+
+def create_postgres_engine(connection_string: str | None = None):
+    if connection_string is None:
+        connection_string = settings.pg_database_url
+    if not connection_string:
+        raise ValueError("PG_DATABASE_URL is not set.")
+    return create_engine(connection_string)
+
+
+Base = declarative_base()
+
+engine = create_sqlite_engine()
+Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_db():
+    db = Session()
+    try:
+        yield db
+    finally:
+        db.close()
+```
+
+### `packages/db/src/{project}_db/models.py`
+```python
+from datetime import datetime
+
+from sqlalchemy import func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from {project}_db.database import Base
+
+
+class UserRecord(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    email: Mapped[str] = mapped_column(unique=True, nullable=False)
+    name: Mapped[str | None] = mapped_column(nullable=True)
+    phone: Mapped[str | None] = mapped_column(nullable=True)
+    avatar_url: Mapped[str | None] = mapped_column(nullable=True)
+    password_hash: Mapped[str | None] = mapped_column(nullable=True)
+    created_at: Mapped[datetime] = mapped_column(default=func.now())
+```
+
+---
+
+### `packages/models/pyproject.toml`
+```toml
+[project]
+name = "{project}-models"
+version = "0.1.0"
+description = "{project} shared Pydantic models"
+requires-python = ">=3.13"
+dependencies = [
+    "pydantic[email]>=2.10.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/{project}_models"]
+```
+
+### `packages/models/src/{project}_models/__init__.py`
+```python
+from .auth import LoginRequest, SignupRequest, TokenResponse, UserResponse
+
+__all__ = ["LoginRequest", "SignupRequest", "TokenResponse", "UserResponse"]
+```
+
+### `packages/models/src/{project}_models/auth.py`
+```python
+from datetime import datetime
+
+from pydantic import BaseModel, EmailStr
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class SignupRequest(BaseModel):
+    email: EmailStr
+    password: str
+    name: str | None = None
+
+
+class UserResponse(BaseModel):
+    id: int
+    email: str
+    name: str | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    user: UserResponse
+```
+
+---
+
+### `packages/utils/pyproject.toml`
+```toml
+[project]
+name = "{project}-utils"
+version = "0.1.0"
+description = "{project} utility functions"
+requires-python = ">=3.13"
+dependencies = [
+    "fastapi>=0.115.0",
+    "bcrypt>=4.0",
+    "python-jose[cryptography]>=3.5.0",
+    "{project}-config",
+    "{project}-db",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/{project}_utils"]
+
+[tool.uv.sources]
+{project}-config = { workspace = true }
+{project}-db = { workspace = true }
+```
+
+### `packages/utils/src/{project}_utils/__init__.py`
+```python
+from .auth import create_token, get_current_user, hash_password, verify_password
+
+__all__ = ["create_token", "get_current_user", "hash_password", "verify_password"]
+```
+
+### `packages/utils/src/{project}_utils/auth.py`
+```python
+from datetime import datetime, timedelta, timezone
+
+import bcrypt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+
+from {project}_config.settings import settings
+from {project}_db.database import get_db
+from {project}_db.models import UserRecord
+
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24  # 24 hours
+
+security = HTTPBearer(auto_error=False)
+
+
+def hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return bcrypt.checkpw(plain.encode(), hashed.encode())
+
+
+def create_token(user_id: int) -> str:
+    expire = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    return jwt.encode(
+        {"sub": str(user_id), "exp": expire},
+        settings.secret_key,
+        algorithm=ALGORITHM,
+    )
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+    db: Session = Depends(get_db),
+) -> UserRecord:
+    if not credentials or credentials.scheme != "Bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing or invalid authorization",
+        )
+    try:
+        payload = jwt.decode(credentials.credentials, settings.secret_key, algorithms=[ALGORITHM])
+        user_id = payload.get("sub")
+        if user_id is None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+        user_id = int(user_id)
+    except (JWTError, ValueError):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    user = db.query(UserRecord).filter(UserRecord.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+    return user
+```
+
+---
+
+### `packages/services/pyproject.toml`
+```toml
+[project]
+name = "{project}-services"
+version = "0.1.0"
+description = "{project} business logic services"
+requires-python = ">=3.13"
+dependencies = [
+    "fastapi>=0.115.0",
+    "sqlalchemy>=2.0.0",
+    "{project}-db",
+    "{project}-models",
+    "{project}-utils",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/{project}_services"]
+
+[tool.uv.sources]
+{project}-config = { workspace = true }
+{project}-db = { workspace = true }
+{project}-models = { workspace = true }
+{project}-utils = { workspace = true }
+```
+
+### `packages/services/src/{project}_services/__init__.py`
+```python
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from {project}_db.database import get_db
+from {project}_services.auth import AuthService
+
+
+def get_auth_service(db: Session = Depends(get_db)) -> AuthService:
+    return AuthService(db)
+```
+
+### `packages/services/src/{project}_services/auth.py`
+```python
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from {project}_db.models import UserRecord
+from {project}_models import LoginRequest, SignupRequest, TokenResponse, UserResponse
+from {project}_utils.auth import create_token, hash_password, verify_password
+
+
+class AuthService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def signup(self, body: SignupRequest) -> TokenResponse:
+        if self.db.query(UserRecord).filter(UserRecord.email == body.email).first():
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail="Email already registered"
+            )
+
+        user = UserRecord(
+            email=body.email,
+            name=body.name,
+            password_hash=hash_password(body.password),
+        )
+        self.db.add(user)
+        self.db.commit()
+        self.db.refresh(user)
+
+        return TokenResponse(
+            access_token=create_token(user.id),
+            user=UserResponse.model_validate(user),
+        )
+
+    def login(self, body: LoginRequest) -> TokenResponse:
+        user = self.db.query(UserRecord).filter(UserRecord.email == body.email).first()
+
+        if (
+            not user
+            or not user.password_hash
+            or not verify_password(body.password, user.password_hash)
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid email or password",
+            )
+
+        return TokenResponse(
+            access_token=create_token(user.id),
+            user=UserResponse.model_validate(user),
+        )
+```
+
+---
+
+## App Templates
+
+### `apps/api/pyproject.toml`
+```toml
+[project]
+name = "{project}-api"
+version = "0.1.0"
+description = "{project} FastAPI application"
+requires-python = ">=3.13"
+dependencies = [
+    "fastapi>=0.115.0",
+    "uvicorn>=0.30.0",
+    "{project}-config",
+    "{project}-db",
+    "{project}-models",
+    "{project}-utils",
+    "{project}-services",
+]
+
+[project.scripts]
+api-start = "api.main:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]
+
+[tool.hatch.build.targets.wheel.sources]
+"src" = ""
+
+[tool.uv.sources]
+{project}-config = { workspace = true }
+{project}-db = { workspace = true }
+{project}-models = { workspace = true }
+{project}-utils = { workspace = true }
+{project}-services = { workspace = true }
+```
+
+### `apps/api/Dockerfile`
+```dockerfile
+# Build from workspace root: docker build -f apps/api/Dockerfile -t {project}-api .
+FROM python:3.13-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    gcc \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+# Copy workspace root config
+COPY pyproject.toml uv.lock ./
+
+# Copy all packages and the API app
+COPY packages/ packages/
+COPY apps/api/ apps/api/
+
+# Install only the API app and its workspace dependencies
+RUN uv sync --frozen --no-dev --no-cache --compile-bytecode --package {project}-api
+
+ENV PYTHONUNBUFFERED=1
+
+EXPOSE 8000
+
+CMD [".venv/bin/api-start"]
+```
+
+### `apps/api/src/api/__init__.py`
+```python
+```
+
+### `apps/api/src/api/main.py`
+```python
+import os
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from api.lifespan import lifespan
+from api.routes import auth_router, core_router
+
+app = FastAPI(lifespan=lifespan)
+
+origins = [
+    "http://localhost:5173",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization"],
+    expose_headers=["Content-Disposition"],
+)
+
+app.include_router(core_router)
+app.include_router(auth_router)
+
+
+def main():
+    reload = os.getenv("API_RELOAD", "false").lower() == "true"
+    if reload:
+        uvicorn.run("api.main:app", host="0.0.0.0", port=8000, reload=True)
+    else:
+        uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+### `apps/api/src/api/lifespan.py`
+```python
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from sqlalchemy import text
+
+from {project}_db.database import Base, engine
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    print("\n" + "=" * 60)
+    print(f"Starting {project} API")
+    print("=" * 60)
+
+    Base.metadata.create_all(bind=engine)
+    print("Database tables created/verified")
+
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+            print("Database connection successful")
+    except Exception as e:
+        print(f"Database connection failed: {e}")
+        print("Application may not function correctly!")
+
+    yield
+
+    engine.dispose()
+    print("{project} API shutdown complete")
+```
+
+### `apps/api/src/api/routes/__init__.py`
+```python
+from .auth import router as auth_router
+from .core import router as core_router
+
+__all__ = ["auth_router", "core_router"]
+```
+
+### `apps/api/src/api/routes/core.py`
+```python
+from fastapi import APIRouter
+
+router = APIRouter(tags=["core"])
+
+
+@router.get("/")
+def root():
+    return {"ok": True, "message": "{project} API is running", "version": "0.1.0"}
+
+
+@router.get("/healthz")
+def healthz():
+    return {"ok": True, "service": "{project}-api", "version": "0.1.0"}
+```
+
+### `apps/api/src/api/routes/auth.py`
+```python
+from fastapi import APIRouter, Depends, status
+
+from {project}_models import LoginRequest, SignupRequest, TokenResponse
+from {project}_services import get_auth_service
+from {project}_services.auth import AuthService
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/signup", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
+def signup(body: SignupRequest, service: AuthService = Depends(get_auth_service)):
+    return service.signup(body)
+
+
+@router.post("/login", response_model=TokenResponse)
+def login(body: LoginRequest, service: AuthService = Depends(get_auth_service)):
+    return service.login(body)
+```
+
+---
+
+## Empty `__init__.py` files
+
+Create empty `__init__.py` for all package directories not listed above.
+
+---
+
+## After Scaffolding — Tell the User
+
+Once all files are created, tell the user:
+
+```bash
+# Install all workspace dependencies
+uv sync
+
+# Copy env file and fill in your values
+cp .env.example .env
+
+# Start the dev server with hot reload
+just dev
+```
+
+The API will be at `http://localhost:8000`. Endpoints:
+- `GET /healthz` — health check
+- `GET /` — root status
+- `POST /auth/signup` — create account, returns JWT
+- `POST /auth/login` — login, returns JWT
+
+To protect a route, add `user: UserRecord = Depends(get_current_user)` from `{project}_utils`.
+
+To add a dependency to a specific package:
+```bash
+uv add --package {project}-api <package>   # add to the API app
+uv add --package {project}-db <package>    # add to the db package
+```
+
+---
+
+## Important Notes
+
+- SQLite is used by default (no external db needed to start). Set `PG_DATABASE_URL` in `.env` to switch to PostgreSQL.
+- Tables are auto-created on startup via `Base.metadata.create_all()` — no migrations needed to start.
+- The `uv.lock` is at the workspace root — a single lock file covers all packages and apps.
+- Docker must be built from the **workspace root** using `just docker-build` (or `docker build -f apps/api/Dockerfile .`).
+- To add a new app, create `apps/{name}/` with its own `pyproject.toml` and add it to the workspace root `pyproject.toml` members list.

--- a/.agents/skills/react-architect/SKILL.md
+++ b/.agents/skills/react-architect/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: react-architect
+description: Audits a React SPA project against architecture rules. Use when asked to "review components", "check architecture", "audit this react project", "does this follow react rules", or "review my frontend structure".
+version: 1.0.0
+---
+
+# React Architect Review
+
+You are an architecture auditor for React SPAs. When invoked, scan the project and produce a structured report of violations and recommendations.
+
+## Architecture Rules
+
+### Directory Layout
+- `src/pages/` — one file per route, no components defined here
+- `src/store/{domain}/` — `slice.ts` + `api.ts` + `index.ts` per domain
+- `src/lib/` — shared utilities only (`api.ts`, `token.ts`, `utils.ts`)
+- `src/components/auth/` — `PrivateRoute` / `PublicRoute` guards only
+- `src/components/ui/` — shadcn components only, never edited manually
+- `src/components/{feature}/` — feature-specific components
+- `src/components/common/` — cross-cutting utility components
+- `src/hooks/` — custom hooks only
+
+### Naming Rules
+- [ ] All filenames must be **kebab-case**: `my-component.tsx`, `private-route.tsx`
+- [ ] Each feature folder must have an `index.ts` barrel export
+
+### Component Rules
+- [ ] Feature-specific components live in `src/components/{feature}/`
+- [ ] Cross-cutting components live in `src/components/common/`
+- [ ] shadcn primitives live in `src/components/ui/` — added via CLI only, never edited
+- [ ] No components defined inside `src/pages/` files
+
+### Store Rules
+- [ ] Always use `useAppDispatch` / `useAppSelector` — never plain `useDispatch` / `useSelector`
+- [ ] Server data fetched via RTK Query in `api.ts`
+- [ ] Client-only state managed via Redux slice in `slice.ts`
+- [ ] Each domain folder has: `slice.ts` + `api.ts` + `index.ts`
+- [ ] All domain stores registered in `src/store/index.ts`
+
+### Routing Rules
+- [ ] All protected routes wrapped with `<PrivateRoute>`
+- [ ] All public-only routes wrapped with `<PublicRoute>`
+- [ ] Routes defined in `src/routes.tsx` only
+
+### Import Rules
+- [ ] All imports use `@/` path aliases
+- [ ] No relative `../../` imports crossing feature boundaries
+
+### Form Rules
+- [ ] Forms use `FieldGroup`, `FieldLabel`, `FieldDescription` from `@/components/ui/field`
+- [ ] `Label` is never used directly in forms — always use `FieldLabel`
+
+### General Rules
+- [ ] `cn()` utility used for all className merging (never string concatenation)
+- [ ] CSS variables referenced as `hsl(var(--primary))`, `hsl(var(--background))`, etc.
+- [ ] All component props have explicit TypeScript types (no `any`)
+- [ ] All async operations have loading and error states
+- [ ] Responsive layout uses Tailwind breakpoints (`sm:`, `md:`, `lg:`)
+
+---
+
+## Review Process
+
+1. **Scan the project structure** — check directories exist and are correctly placed
+2. **Check all filenames** — enforce kebab-case across `src/`
+3. **Check store structure** — each domain has `slice.ts` + `api.ts` + `index.ts`, all registered in `src/store/index.ts`
+4. **Read route files** (`src/routes.tsx`) — verify `<PrivateRoute>` / `<PublicRoute>` usage
+5. **Read component files** — check placement, barrel exports, no components in pages
+6. **Read form files** — check `FieldGroup` / `FieldLabel` / `FieldDescription` usage
+7. **Check imports** — no relative cross-boundary imports, all use `@/`
+8. **Check hooks usage** — `useAppDispatch` / `useAppSelector` only
+
+---
+
+## Output Format
+
+Produce a report in this structure:
+
+```
+## Architecture Review
+
+### ✅ Passing
+- <list of rules that are correctly followed>
+
+### ❌ Violations
+#### <file path>
+- **Rule:** <rule that is violated>
+- **Found:** <what the code actually does>
+- **Fix:** <exact change needed>
+
+### ⚠️ Warnings
+- <things that are not violations but could be improved>
+
+### Summary
+X violations found in Y files.
+```
+
+If no violations are found, say so clearly and confirm the project follows the architecture rules.

--- a/.claude/skills/commit
+++ b/.claude/skills/commit
@@ -1,0 +1,1 @@
+../../.agents/skills/commit

--- a/.claude/skills/fastapi-architect
+++ b/.claude/skills/fastapi-architect
@@ -1,0 +1,1 @@
+../../.agents/skills/fastapi-architect

--- a/.claude/skills/fastapi-monorepo-setup
+++ b/.claude/skills/fastapi-monorepo-setup
@@ -1,0 +1,1 @@
+../../.agents/skills/fastapi-monorepo-setup

--- a/.claude/skills/react-architect
+++ b/.claude/skills/react-architect
@@ -1,0 +1,1 @@
+../../.agents/skills/react-architect

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,11 @@ Zenve monorepo root.
 
 ```
 server/   # FastAPI backend (see server/CLAUDE.md)
-ui/       # Frontend
+ui/       # Frontend (see ui/CLAUDE.md)
 agents/   # Agent definitions
 ```
 
 ## Sub-project docs
 
 - [server/CLAUDE.md](server/CLAUDE.md) — FastAPI monorepo: architecture rules, layer rules, dev commands
+- [ui/CLAUDE.md](ui/CLAUDE.md) — React SPA: stack, structure, Redux/RTK Query, routing, component rules

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,26 @@
 {
   "version": 1,
   "skills": {
+    "commit": {
+      "source": "ghalex/skills",
+      "sourceType": "github",
+      "computedHash": "8f006b38d44e09176c4f5ea5589efefa06a253a08ad171871f15b361dae7ab64"
+    },
+    "fastapi-architect": {
+      "source": "ghalex/skills",
+      "sourceType": "github",
+      "computedHash": "002c350c25fd1a1be1a5fc252a1fe4f57d547e8ff0fd3185c004a167b1e60f15"
+    },
+    "fastapi-monorepo-setup": {
+      "source": "ghalex/skills",
+      "sourceType": "github",
+      "computedHash": "299513592c8a7221ad93d2b118090a2e3d3e35fe7069dcb90b9622af26ec4248"
+    },
+    "react-architect": {
+      "source": "ghalex/skills",
+      "sourceType": "github",
+      "computedHash": "f2f96a9bcb01227177352d450b7aa2e43d101ce85ee8d24c8942fd904cc2ca6f"
+    },
     "react-setup": {
       "source": "ghalex/skills",
       "sourceType": "github",

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,4 +1,0 @@
-VITE_APP_NAME=zenve
-VITE_API_URL=http://localhost:8000
-VITE_TOKEN_KEY=app-token
-VITE_USER_KEY=app-user

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -19,5 +19,10 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      // shadcn/ui and similar patterns export hooks + `cva` helpers alongside components.
+      // Fast Refresh still works in practice; the rule is overly strict for that style.
+      'react-refresh/only-export-components': 'off',
+    },
   },
 ])

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "typecheck": "tsc -b",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -3,12 +3,14 @@ import './main.css'
 import AppRoutes from '@/routes'
 import { useAppDispatch } from '@/store/hooks'
 import { restoreFromStorage } from '@/store/auth'
+import { restoreFromStorage as restoreOrganizationFromStorage } from '@/store/organization'
 
 export default function App() {
   const dispatch = useAppDispatch()
 
   useEffect(() => {
     dispatch(restoreFromStorage())
+    dispatch(restoreOrganizationFromStorage())
   }, [dispatch])
 
   return <AppRoutes />

--- a/ui/src/components/layout/app-sidebar.tsx
+++ b/ui/src/components/layout/app-sidebar.tsx
@@ -1,16 +1,8 @@
-import { BookOpen, Bot, Command, Settings2, SquareTerminal } from 'lucide-react'
+import { BookOpen, Bot, Settings2, SquareTerminal } from 'lucide-react'
 import { NavMain } from './nav-main'
 import { NavUser } from './nav-user'
-import {
-  Sidebar,
-  SidebarContent,
-  SidebarFooter,
-  SidebarHeader,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-} from '@/components/ui/sidebar'
-import config from '@/config'
+import { OrganizationSwitcher } from './organization-switcher'
+import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader } from '@/components/ui/sidebar'
 
 const navItems = [
   {
@@ -62,20 +54,7 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   return (
     <Sidebar variant="inset" {...props}>
       <SidebarHeader>
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton size="lg" asChild>
-              <a href="#">
-                <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
-                  <Command className="size-4" />
-                </div>
-                <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-medium">{config.appName}</span>
-                </div>
-              </a>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        </SidebarMenu>
+        <OrganizationSwitcher />
       </SidebarHeader>
       <SidebarContent>
         <NavMain items={navItems} />

--- a/ui/src/components/layout/organization-switcher.tsx
+++ b/ui/src/components/layout/organization-switcher.tsx
@@ -1,0 +1,140 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router'
+import {
+  Box,
+  Building2,
+  ChevronsUpDown,
+  Cpu,
+  Layers,
+  Plus,
+  Triangle,
+  Zap,
+  type LucideIcon,
+} from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'
+import { useAppDispatch, useAppSelector } from '@/store/hooks'
+import {
+  selectCurrentOrganization,
+  selectOrganizations,
+  setCurrentOrganization,
+} from '@/store/organization'
+import type { OrganizationIconKey } from '@/types'
+
+const ORG_ICONS: Record<OrganizationIconKey, LucideIcon> = {
+  zap: Zap,
+  triangle: Triangle,
+  box: Box,
+  cpu: Cpu,
+  building: Building2,
+  layers: Layers,
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  const tag = target.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  if (target.isContentEditable) return true
+  return false
+}
+
+const MOD_SYMBOL =
+  typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+    ? '⌘'
+    : 'Ctrl+'
+
+export function OrganizationSwitcher() {
+  const dispatch = useAppDispatch()
+  const navigate = useNavigate()
+  const organizations = useAppSelector(selectOrganizations)
+  const current = useAppSelector(selectCurrentOrganization)
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!e.metaKey && !e.ctrlKey) return
+      if (e.altKey || e.shiftKey) return
+      if (isEditableTarget(e.target)) return
+      const match = /^Digit([1-9])$/.exec(e.code)
+      if (!match) return
+      const index = Number(match[1]) - 1
+      const org = organizations[index]
+      if (!org) return
+      e.preventDefault()
+      dispatch(setCurrentOrganization(org.id))
+      navigate(`/${org.slug}`)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [dispatch, navigate, organizations])
+
+  if (!current) return null
+
+  const CurrentIcon = ORG_ICONS[current.iconKey] ?? Box
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <SidebarMenuButton
+              size="lg"
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            >
+              <div className="flex aspect-square size-8 items-center justify-center rounded-lg border border-sidebar-border bg-sidebar text-sidebar-foreground">
+                <CurrentIcon className="size-4" />
+              </div>
+              <div className="grid min-w-0 flex-1 text-left text-sm leading-tight">
+                <span className="truncate font-medium">{current.name}</span>
+                <span className="truncate text-xs text-muted-foreground">{current.role}</span>
+              </div>
+              <ChevronsUpDown className="ml-auto size-4 shrink-0 opacity-50" />
+            </SidebarMenuButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-[--radix-dropdown-menu-trigger-width] min-w-56" align="start">
+            <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+              Organizations
+            </DropdownMenuLabel>
+            <DropdownMenuGroup>
+              {organizations.map((org, i) => {
+                const Icon = ORG_ICONS[org.iconKey] ?? Box
+                const shortcut = i < 9 ? `${MOD_SYMBOL}${i + 1}` : undefined
+                return (
+                  <DropdownMenuItem
+                    key={org.id}
+                    className="gap-2"
+                    onSelect={() => {
+                      dispatch(setCurrentOrganization(org.id))
+                      navigate(`/${org.slug}`)
+                    }}
+                  >
+                    <div className="flex size-8 shrink-0 items-center justify-center rounded-md border bg-muted/40">
+                      <Icon className="size-4 text-muted-foreground" />
+                    </div>
+                    <span className="min-w-0 flex-1 truncate">{org.name}</span>
+                    {shortcut ? <DropdownMenuShortcut>{shortcut}</DropdownMenuShortcut> : null}
+                  </DropdownMenuItem>
+                )
+              })}
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem className="gap-2" onSelect={() => {}}>
+              <div className="flex size-8 shrink-0 items-center justify-center rounded-md border bg-muted/40">
+                <Plus className="size-4 text-muted-foreground" />
+              </div>
+              <span>Create organization</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}

--- a/ui/src/components/ui/avatar.tsx
+++ b/ui/src/components/ui/avatar.tsx
@@ -1,16 +1,21 @@
 import * as React from "react"
 import { Avatar as AvatarPrimitive } from "radix-ui"
+
 import { cn } from "@/lib/utils"
 
 function Avatar({
   className,
+  size = "default",
   ...props
-}: React.ComponentProps<typeof AvatarPrimitive.Root>) {
+}: React.ComponentProps<typeof AvatarPrimitive.Root> & {
+  size?: "default" | "sm" | "lg"
+}) {
   return (
     <AvatarPrimitive.Root
       data-slot="avatar"
+      data-size={size}
       className={cn(
-        "relative flex size-8 shrink-0 overflow-hidden rounded-full",
+        "group/avatar relative flex size-8 shrink-0 overflow-hidden rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6",
         className
       )}
       {...props}
@@ -39,7 +44,7 @@ function AvatarFallback({
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
       className={cn(
-        "bg-muted flex size-full items-center justify-center rounded-full",
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
         className
       )}
       {...props}
@@ -47,4 +52,56 @@ function AvatarFallback({
   )
 }
 
-export { Avatar, AvatarImage, AvatarFallback }
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground ring-2 ring-background select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarBadge,
+  AvatarGroup,
+  AvatarGroupCount,
+}

--- a/ui/src/components/ui/breadcrumb.tsx
+++ b/ui/src/components/ui/breadcrumb.tsx
@@ -1,10 +1,11 @@
 import * as React from "react"
-import { Slot } from "radix-ui"
 import { ChevronRight, MoreHorizontal } from "lucide-react"
+import { Slot } from "radix-ui"
+
 import { cn } from "@/lib/utils"
 
 function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
-  return <nav data-slot="breadcrumb" aria-label="breadcrumb" {...props} />
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />
 }
 
 function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
@@ -12,7 +13,7 @@ function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
     <ol
       data-slot="breadcrumb-list"
       className={cn(
-        "text-muted-foreground flex flex-wrap items-center gap-1.5 break-words text-sm sm:gap-2.5",
+        "flex flex-wrap items-center gap-1.5 text-sm break-words text-muted-foreground sm:gap-2.5",
         className
       )}
       {...props}
@@ -42,7 +43,7 @@ function BreadcrumbLink({
   return (
     <Comp
       data-slot="breadcrumb-link"
-      className={cn("hover:text-foreground transition-colors", className)}
+      className={cn("transition-colors hover:text-foreground", className)}
       {...props}
     />
   )
@@ -55,7 +56,7 @@ function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
       role="link"
       aria-disabled="true"
       aria-current="page"
-      className={cn("text-foreground font-normal", className)}
+      className={cn("font-normal text-foreground", className)}
       {...props}
     />
   )

--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -1,30 +1,34 @@
 import * as React from "react"
-import { Slot } from "radix-ui"
 import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
         outline:
-          "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
+        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-8",
+        "icon-lg": "size-10",
       },
     },
     defaultVariants: {
@@ -36,8 +40,8 @@ const buttonVariants = cva(
 
 function Button({
   className,
-  variant,
-  size,
+  variant = "default",
+  size = "default",
   asChild = false,
   ...props
 }: React.ComponentProps<"button"> &
@@ -49,6 +53,8 @@ function Button({
   return (
     <Comp
       data-slot="button"
+      data-variant={variant}
+      data-size={size}
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />

--- a/ui/src/components/ui/card.tsx
+++ b/ui/src/components/ui/card.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+
 import { cn } from "@/lib/utils"
 
 function Card({ className, ...props }: React.ComponentProps<"div">) {
@@ -6,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
         className
       )}
       {...props}
@@ -19,7 +20,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
         className
       )}
       {...props}
@@ -41,7 +42,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
   )

--- a/ui/src/components/ui/collapsible.tsx
+++ b/ui/src/components/ui/collapsible.tsx
@@ -1,7 +1,31 @@
 import { Collapsible as CollapsiblePrimitive } from "radix-ui"
 
-const Collapsible = CollapsiblePrimitive.Root
-const CollapsibleTrigger = CollapsiblePrimitive.Trigger
-const CollapsibleContent = CollapsiblePrimitive.Content
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  )
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      {...props}
+    />
+  )
+}
 
 export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/ui/src/components/ui/dropdown-menu.tsx
+++ b/ui/src/components/ui/dropdown-menu.tsx
@@ -1,50 +1,31 @@
+"use client"
+
 import * as React from "react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
-import { Check, ChevronRight, Circle } from "lucide-react"
+
 import { cn } from "@/lib/utils"
 
-const DropdownMenu = DropdownMenuPrimitive.Root
-const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
-const DropdownMenuGroup = DropdownMenuPrimitive.Group
-const DropdownMenuPortal = DropdownMenuPrimitive.Portal
-const DropdownMenuSub = DropdownMenuPrimitive.Sub
-const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
-
-function DropdownMenuSubTrigger({
-  className,
-  inset,
-  children,
+function DropdownMenu({
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
-  inset?: boolean
-}) {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
   return (
-    <DropdownMenuPrimitive.SubTrigger
-      data-slot="dropdown-menu-sub-trigger"
-      data-inset={inset}
-      className={cn(
-        "focus:bg-accent data-[state=open]:bg-accent flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
-      )}
-      {...props}
-    >
-      {children}
-      <ChevronRight className="ml-auto" />
-    </DropdownMenuPrimitive.SubTrigger>
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
   )
 }
 
-function DropdownMenuSubContent({
-  className,
+function DropdownMenuTrigger({
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
   return (
-    <DropdownMenuPrimitive.SubContent
-      data-slot="dropdown-menu-sub-content"
-      className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg",
-        className
-      )}
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
       {...props}
     />
   )
@@ -61,12 +42,20 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         {...props}
       />
     </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
   )
 }
 
@@ -85,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
         className
       )}
       {...props}
@@ -103,7 +92,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
@@ -111,11 +100,22 @@ function DropdownMenuCheckboxItem({
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <Check className="size-4" />
+          <CheckIcon className="size-4" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
     </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
   )
 }
 
@@ -128,14 +128,14 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <Circle className="size-2 fill-current" />
+          <CircleIcon className="size-2 fill-current" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -155,7 +155,7 @@ function DropdownMenuLabel({
       data-slot="dropdown-menu-label"
       data-inset={inset}
       className={cn(
-        "px-2 py-1.5 text-xs font-medium data-[inset]:pl-8",
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
         className
       )}
       {...props}
@@ -170,7 +170,7 @@ function DropdownMenuSeparator({
   return (
     <DropdownMenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
-      className={cn("bg-muted -mx-1 my-1 h-px", className)}
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
       {...props}
     />
   )
@@ -184,7 +184,53 @@ function DropdownMenuShortcut({
     <span
       data-slot="dropdown-menu-shortcut"
       className={cn(
-        "text-muted-foreground ml-auto text-xs tracking-widest",
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
         className
       )}
       {...props}
@@ -194,18 +240,18 @@ function DropdownMenuShortcut({
 
 export {
   DropdownMenu,
+  DropdownMenuPortal,
   DropdownMenuTrigger,
   DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
   DropdownMenuItem,
   DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
-  DropdownMenuGroup,
-  DropdownMenuPortal,
   DropdownMenuSub,
-  DropdownMenuSubContent,
   DropdownMenuSubTrigger,
-  DropdownMenuRadioGroup,
+  DropdownMenuSubContent,
 }

--- a/ui/src/components/ui/field.tsx
+++ b/ui/src/components/ui/field.tsx
@@ -1,21 +1,105 @@
-import * as React from "react"
-import { cn } from "@/lib/utils"
+import { useMemo } from "react"
+import { cva, type VariantProps } from "class-variance-authority"
 
-function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
   return (
-    <div
-      data-slot="field-group"
-      className={cn("flex flex-col gap-4", className)}
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        "flex flex-col gap-6",
+        "has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        className
+      )}
       {...props}
     />
   )
 }
 
-function Field({ className, ...props }: React.ComponentProps<"div">) {
+function FieldLegend({
+  className,
+  variant = "legend",
+  ...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        "mb-3 font-medium",
+        "data-[variant=legend]:text-base",
+        "data-[variant=label]:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
+      data-slot="field-group"
+      className={cn(
+        "group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const fieldVariants = cva(
+  "group/field flex w-full gap-3 data-[invalid=true]:text-destructive",
+  {
+    variants: {
+      orientation: {
+        vertical: ["flex-col [&>*]:w-full [&>.sr-only]:w-auto"],
+        horizontal: [
+          "flex-row items-center",
+          "[&>[data-slot=field-label]]:flex-auto",
+          "has-[>[data-slot=field-content]]:items-start has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        ],
+        responsive: [
+          "flex-col @md/field-group:flex-row @md/field-group:items-center [&>*]:w-full @md/field-group:[&>*]:w-auto [&>.sr-only]:w-auto",
+          "@md/field-group:[&>[data-slot=field-label]]:flex-auto",
+          "@md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        ],
+      },
+    },
+    defaultVariants: {
+      orientation: "vertical",
+    },
+  }
+)
+
+function Field({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      role="group"
       data-slot="field"
-      className={cn("flex flex-col gap-2", className)}
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn(
+        "group/field-content flex flex-1 flex-col gap-1.5 leading-snug",
+        className
+      )}
       {...props}
     />
   )
@@ -23,76 +107,140 @@ function Field({ className, ...props }: React.ComponentProps<"div">) {
 
 function FieldLabel({
   className,
-  htmlFor,
-  children,
   ...props
-}: React.ComponentProps<"label"> & { htmlFor?: string }) {
+}: React.ComponentProps<typeof Label>) {
   return (
-    <label
+    <Label
       data-slot="field-label"
-      htmlFor={htmlFor}
       className={cn(
-        "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4",
+        "has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/5 dark:has-data-[state=checked]:bg-primary/10",
         className
       )}
-      {...props}
-    >
-      {children}
-    </label>
-  )
-}
-
-function FieldDescription({
-  className,
-  ...props
-}: React.ComponentProps<"p">) {
-  return (
-    <p
-      data-slot="field-description"
-      className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
   )
 }
 
-function FieldMessage({ className, ...props }: React.ComponentProps<"p">) {
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm leading-snug font-medium group-data-[disabled=true]/field:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
   return (
     <p
-      data-slot="field-message"
-      className={cn("text-destructive text-sm font-medium", className)}
+      data-slot="field-description"
+      className={cn(
+        "text-sm leading-normal font-normal text-muted-foreground group-has-[[data-orientation=horizontal]]/field:text-balance",
+        "last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
       {...props}
     />
   )
 }
 
 function FieldSeparator({
-  className,
   children,
+  className,
   ...props
-}: React.ComponentProps<"div">) {
+}: React.ComponentProps<"div"> & {
+  children?: React.ReactNode
+}) {
   return (
     <div
       data-slot="field-separator"
-      className={cn("relative flex items-center gap-3 text-sm", className)}
+      data-content={!!children}
+      className={cn(
+        "relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+        className
+      )}
       {...props}
     >
-      <div className="h-px flex-1 bg-border" />
-      <span
-        data-slot="field-separator-content"
-        className="text-muted-foreground"
-      >
-        {children}
-      </span>
-      <div className="h-px flex-1 bg-border" />
+      <Separator className="absolute inset-0 top-1/2" />
+      {children && (
+        <span
+          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children
+    }
+
+    if (!errors?.length) {
+      return null
+    }
+
+    const uniqueErrors = [
+      ...new Map(errors.map((error) => [error?.message, error])).values(),
+    ]
+
+    if (uniqueErrors?.length == 1) {
+      return uniqueErrors[0]?.message
+    }
+
+    return (
+      <ul className="ml-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map(
+          (error, index) =>
+            error?.message && <li key={index}>{error.message}</li>
+        )}
+      </ul>
+    )
+  }, [children, errors])
+
+  if (!content) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("text-sm font-normal text-destructive", className)}
+      {...props}
+    >
+      {content}
     </div>
   )
 }
 
 export {
   Field,
-  FieldGroup,
   FieldLabel,
   FieldDescription,
-  FieldMessage,
+  FieldError,
+  FieldGroup,
+  FieldLegend,
   FieldSeparator,
+  FieldSet,
+  FieldContent,
+  FieldTitle,
 }

--- a/ui/src/components/ui/input.tsx
+++ b/ui/src/components/ui/input.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+
 import { cn } from "@/lib/utils"
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
@@ -7,9 +8,9 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/ui/src/components/ui/label.tsx
+++ b/ui/src/components/ui/label.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/ui/src/components/ui/separator.tsx
+++ b/ui/src/components/ui/separator.tsx
@@ -1,5 +1,8 @@
+"use client"
+
 import * as React from "react"
 import { Separator as SeparatorPrimitive } from "radix-ui"
+
 import { cn } from "@/lib/utils"
 
 function Separator({
@@ -14,7 +17,7 @@ function Separator({
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
         className
       )}
       {...props}

--- a/ui/src/components/ui/sheet.tsx
+++ b/ui/src/components/ui/sheet.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+          side === "right" &&
+            "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          side === "left" &&
+            "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          side === "top" &&
+            "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+          side === "bottom" &&
+            "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("font-semibold text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/ui/src/components/ui/sidebar.tsx
+++ b/ui/src/components/ui/sidebar.tsx
@@ -1,11 +1,29 @@
+"use client"
+
 import * as React from "react"
-import { Slot } from "radix-ui"
-import { PanelLeft } from "lucide-react"
 import { cva, type VariantProps } from "class-variance-authority"
+import { PanelLeftIcon } from "lucide-react"
+import { Slot } from "radix-ui"
+
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
@@ -28,7 +46,10 @@ const SidebarContext = React.createContext<SidebarContextProps | null>(null)
 
 function useSidebar() {
   const context = React.useContext(SidebarContext)
-  if (!context) throw new Error("useSidebar must be used within SidebarProvider")
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.")
+  }
+
   return context
 }
 
@@ -47,9 +68,11 @@ function SidebarProvider({
 }) {
   const isMobile = useIsMobile()
   const [openMobile, setOpenMobile] = React.useState(false)
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
   const [_open, _setOpen] = React.useState(defaultOpen)
   const open = openProp ?? _open
-
   const setOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
       const openState = typeof value === "function" ? value(open) : value
@@ -58,17 +81,19 @@ function SidebarProvider({
       } else {
         _setOpen(openState)
       }
+
+      // This sets the cookie to keep the sidebar state.
       document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
     },
     [setOpenProp, open]
   )
 
+  // Helper to toggle the sidebar.
   const toggleSidebar = React.useCallback(() => {
-    return isMobile
-      ? setOpenMobile((open) => !open)
-      : setOpen((open) => !open)
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
   }, [isMobile, setOpen, setOpenMobile])
 
+  // Adds a keyboard shortcut to toggle the sidebar.
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
@@ -79,10 +104,13 @@ function SidebarProvider({
         toggleSidebar()
       }
     }
+
     window.addEventListener("keydown", handleKeyDown)
     return () => window.removeEventListener("keydown", handleKeyDown)
   }, [toggleSidebar])
 
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
   const state = open ? "expanded" : "collapsed"
 
   const contextValue = React.useMemo<SidebarContextProps>(
@@ -100,23 +128,25 @@ function SidebarProvider({
 
   return (
     <SidebarContext.Provider value={contextValue}>
-      <div
-        data-slot="sidebar-provider"
-        style={
-          {
-            "--sidebar-width": SIDEBAR_WIDTH,
-            "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
-            ...style,
-          } as React.CSSProperties
-        }
-        className={cn(
-          "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
-          className
-        )}
-        {...props}
-      >
-        {children}
-      </div>
+      <TooltipProvider delayDuration={0}>
+        <div
+          data-slot="sidebar-wrapper"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH,
+              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+              ...style,
+            } as React.CSSProperties
+          }
+          className={cn(
+            "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </div>
+      </TooltipProvider>
     </SidebarContext.Provider>
   )
 }
@@ -140,7 +170,7 @@ function Sidebar({
       <div
         data-slot="sidebar"
         className={cn(
-          "bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col",
+          "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
           className
         )}
         {...props}
@@ -152,46 +182,43 @@ function Sidebar({
 
   if (isMobile) {
     return (
-      <div
-        data-slot="sidebar"
-        data-mobile="true"
-        style={{ "--sidebar-width": SIDEBAR_WIDTH_MOBILE } as React.CSSProperties}
-        {...props}
-      >
-        {openMobile && (
-          <div
-            className="fixed inset-0 z-50 bg-black/50"
-            onClick={() => setOpenMobile(false)}
-          />
-        )}
-        <div
-          data-state={openMobile ? "open" : "closed"}
-          className={cn(
-            "bg-sidebar fixed inset-y-0 z-50 flex h-full w-(--sidebar-width) flex-col transition-transform duration-300",
-            side === "left"
-              ? "left-0 data-[state=closed]:-translate-x-full"
-              : "right-0 data-[state=closed]:translate-x-full",
-            className
-          )}
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
         >
-          {children}
-        </div>
-      </div>
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
     )
   }
 
   return (
     <div
-      className="text-sidebar-foreground group peer hidden md:block"
+      className="group peer hidden text-sidebar-foreground md:block"
       data-state={state}
       data-collapsible={state === "collapsed" ? collapsible : ""}
       data-variant={variant}
       data-side={side}
       data-slot="sidebar"
     >
+      {/* This is what handles the sidebar gap on desktop */}
       <div
+        data-slot="sidebar-gap"
         className={cn(
-          "relative h-svh w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
           "group-data-[collapsible=offcanvas]:w-0",
           "group-data-[side=right]:rotate-180",
           variant === "floating" || variant === "inset"
@@ -200,11 +227,13 @@ function Sidebar({
         )}
       />
       <div
+        data-slot="sidebar-container"
         className={cn(
           "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
           side === "left"
             ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
             : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+          // Adjust the padding for floating and inset variants.
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
             : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
@@ -214,7 +243,8 @@ function Sidebar({
       >
         <div
           data-sidebar="sidebar"
-          className="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+          data-slot="sidebar-inner"
+          className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow-sm"
         >
           {children}
         </div>
@@ -229,10 +259,11 @@ function SidebarTrigger({
   ...props
 }: React.ComponentProps<typeof Button>) {
   const { toggleSidebar } = useSidebar()
+
   return (
     <Button
-      data-slot="sidebar-trigger"
       data-sidebar="trigger"
+      data-slot="sidebar-trigger"
       variant="ghost"
       size="icon"
       className={cn("size-7", className)}
@@ -242,7 +273,7 @@ function SidebarTrigger({
       }}
       {...props}
     >
-      <PanelLeft />
+      <PanelLeftIcon />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   )
@@ -250,18 +281,20 @@ function SidebarTrigger({
 
 function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
   const { toggleSidebar } = useSidebar()
+
   return (
     <button
+      data-sidebar="rail"
       data-slot="sidebar-rail"
       aria-label="Toggle Sidebar"
       tabIndex={-1}
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
-        "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
+        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
+        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
         "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
         "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
         className
@@ -276,8 +309,8 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-background relative flex min-h-svh flex-1 flex-col",
-        "peer-data-[variant=inset]:min-h-[calc(100svh-(--spacing(4)))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        "relative flex w-full flex-1 flex-col bg-background",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className
       )}
       {...props}
@@ -288,15 +321,12 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
 function SidebarInput({
   className,
   ...props
-}: React.ComponentProps<"input">) {
+}: React.ComponentProps<typeof Input>) {
   return (
-    <input
+    <Input
       data-slot="sidebar-input"
       data-sidebar="input"
-      className={cn(
-        "bg-background focus-visible:ring-sidebar-ring h-8 w-full rounded-md border-none shadow-none focus-visible:ring-2",
-        className
-      )}
+      className={cn("h-8 w-full bg-background shadow-none", className)}
       {...props}
     />
   )
@@ -332,7 +362,7 @@ function SidebarSeparator({
     <Separator
       data-slot="sidebar-separator"
       data-sidebar="separator"
-      className={cn("bg-sidebar-border mx-2 w-auto", className)}
+      className={cn("mx-2 w-auto bg-sidebar-border", className)}
       {...props}
     />
   )
@@ -369,12 +399,13 @@ function SidebarGroupLabel({
   ...props
 }: React.ComponentProps<"div"> & { asChild?: boolean }) {
   const Comp = asChild ? Slot.Root : "div"
+
   return (
     <Comp
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-none transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className
       )}
@@ -389,13 +420,15 @@ function SidebarGroupAction({
   ...props
 }: React.ComponentProps<"button"> & { asChild?: boolean }) {
   const Comp = asChild ? Slot.Root : "button"
+
   return (
     <Comp
       data-slot="sidebar-group-action"
       data-sidebar="group-action"
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-none transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
-        "after:absolute after:-inset-2 after:md:hidden",
+        "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
         "group-data-[collapsible=icon]:hidden",
         className
       )}
@@ -441,7 +474,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -470,13 +503,13 @@ function SidebarMenuButton({
   tooltip,
   className,
   ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof sidebarMenuButtonVariants> & {
-    asChild?: boolean
-    isActive?: boolean
-    tooltip?: string | React.ComponentProps<"div">
-  }) {
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean
+  isActive?: boolean
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>
+} & VariantProps<typeof sidebarMenuButtonVariants>) {
   const Comp = asChild ? Slot.Root : "button"
+  const { isMobile, state } = useSidebar()
 
   const button = (
     <Comp
@@ -489,7 +522,27 @@ function SidebarMenuButton({
     />
   )
 
-  return button
+  if (!tooltip) {
+    return button
+  }
+
+  if (typeof tooltip === "string") {
+    tooltip = {
+      children: tooltip,
+    }
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent
+        side="right"
+        align="center"
+        hidden={state !== "collapsed" || isMobile}
+        {...tooltip}
+      />
+    </Tooltip>
+  )
 }
 
 function SidebarMenuAction({
@@ -502,15 +555,21 @@ function SidebarMenuAction({
   showOnHover?: boolean
 }) {
   const Comp = asChild ? Slot.Root : "button"
+
   return (
     <Comp
       data-slot="sidebar-menu-action"
       data-sidebar="menu-action"
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-none transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
-        "after:absolute after:-inset-2 after:md:hidden",
+        "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform peer-hover/menu-button:text-sidebar-accent-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
         showOnHover &&
-          "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
+          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground data-[state=open]:opacity-100 md:opacity-0",
         className
       )}
       {...props}
@@ -527,8 +586,12 @@ function SidebarMenuBadge({
       data-slot="sidebar-menu-badge"
       data-sidebar="menu-badge"
       className={cn(
-        "text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums",
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none",
         "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
         className
       )}
       {...props}
@@ -543,9 +606,15 @@ function SidebarMenuSkeleton({
 }: React.ComponentProps<"div"> & {
   showIcon?: boolean
 }) {
+  const instanceId = React.useId()
+  // Stable pseudo-random width between 50% and 90% (derived from useId, pure in render).
   const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`
-  }, [])
+    let n = 0
+    for (let i = 0; i < instanceId.length; i++) {
+      n = (n + instanceId.charCodeAt(i) * (i + 1)) % 40
+    }
+    return `${n + 50}%`
+  }, [instanceId])
 
   return (
     <div
@@ -555,11 +624,19 @@ function SidebarMenuSkeleton({
       {...props}
     >
       {showIcon && (
-        <div className="bg-sidebar-accent size-4 shrink-0 rounded-md" />
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
       )}
-      <div
-        className="bg-sidebar-accent h-4 max-w-[--skeleton-width] flex-1 rounded-md"
-        style={{ "--skeleton-width": width } as React.CSSProperties}
+      <Skeleton
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            "--skeleton-width": width,
+          } as React.CSSProperties
+        }
       />
     </div>
   )
@@ -571,7 +648,7 @@ function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
       data-slot="sidebar-menu-sub"
       data-sidebar="menu-sub"
       className={cn(
-        "border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
+        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5",
         "group-data-[collapsible=icon]:hidden",
         className
       )}
@@ -606,6 +683,7 @@ function SidebarMenuSubButton({
   isActive?: boolean
 }) {
   const Comp = asChild ? Slot.Root : "a"
+
   return (
     <Comp
       data-slot="sidebar-menu-sub-button"
@@ -613,7 +691,7 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
         "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
         size === "sm" && "text-xs",
         size === "md" && "text-sm",
@@ -645,25 +723,9 @@ export {
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
-  SidebarMenuSeparator,
   SidebarProvider,
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,
-}
-
-function SidebarMenuSeparator({
-  className,
-  ...props
-}: React.ComponentProps<"li">) {
-  return (
-    <li
-      data-slot="sidebar-menu-separator"
-      data-sidebar="menu-separator"
-      role="separator"
-      className={cn("bg-sidebar-border mx-2 h-px", className)}
-      {...props}
-    />
-  )
 }

--- a/ui/src/components/ui/skeleton.tsx
+++ b/ui/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-accent", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/ui/src/components/ui/tooltip.tsx
+++ b/ui/src/components/ui/tooltip.tsx
@@ -1,0 +1,55 @@
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/ui/src/hooks/use-mobile.ts
+++ b/ui/src/hooks/use-mobile.ts
@@ -1,16 +1,18 @@
-import { useEffect, useState } from 'react'
+import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = useState<boolean | undefined>(undefined)
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
-  useEffect(() => {
+  React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    mql.addEventListener('change', onChange)
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    }
+    mql.addEventListener("change", onChange)
     setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener('change', onChange)
+    return () => mql.removeEventListener("change", onChange)
   }, [])
 
   return !!isMobile

--- a/ui/src/lib/constants/organizations.ts
+++ b/ui/src/lib/constants/organizations.ts
@@ -1,0 +1,47 @@
+import type { OrganizationSummary } from '@/types'
+
+/** Static catalog for UI-first multi-org; replace with API data later. */
+export const MOCK_ORGANIZATIONS: OrganizationSummary[] = [
+  {
+    id: 'org-zapant',
+    name: 'Zapant',
+    slug: 'zapant',
+    role: 'Owner',
+    iconKey: 'zap',
+  },
+  {
+    id: 'org-pretulmeu',
+    name: 'PretulMeu',
+    slug: 'pretulmeu',
+    role: 'Owner',
+    iconKey: 'triangle',
+  },
+  {
+    id: 'org-demo',
+    name: 'Demo',
+    slug: 'demo',
+    role: 'Admin',
+    iconKey: 'box',
+  },
+  {
+    id: 'org-primarie',
+    name: 'Primarie',
+    slug: 'primarie',
+    role: 'Member',
+    iconKey: 'cpu',
+  },
+  {
+    id: 'org-logzai',
+    name: 'LogzAI',
+    slug: 'logzai',
+    role: 'Owner',
+    iconKey: 'layers',
+  },
+  {
+    id: 'org-swapearn',
+    name: 'SwapEarn',
+    slug: 'swapearn',
+    role: 'Admin',
+    iconKey: 'building',
+  },
+]

--- a/ui/src/pages/home.tsx
+++ b/ui/src/pages/home.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+import { Navigate, useNavigate, useParams } from 'react-router'
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -9,8 +11,40 @@ import {
 import { Separator } from '@/components/ui/separator'
 import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/layout'
+import { useAppDispatch, useAppSelector } from '@/store/hooks'
+import {
+  useListOrganizationsQuery,
+  resolveOrgFromSlug,
+  selectCurrentOrgId,
+  selectOrganizations,
+  setCurrentOrganization,
+} from '@/store/organization'
+import { OrgLoading } from './org-loading'
 
 export default function Home() {
+  const { orgSlug } = useParams<{ orgSlug: string }>()
+  const navigate = useNavigate()
+  const dispatch = useAppDispatch()
+  const { isLoading, isFetching, isSuccess, isError, data } = useListOrganizationsQuery()
+  const organizations = useAppSelector(selectOrganizations)
+  const currentOrgId = useAppSelector(selectCurrentOrgId)
+
+  useEffect(() => {
+    if (!isSuccess || !organizations.length || !orgSlug) return
+    const match = resolveOrgFromSlug(organizations, orgSlug)
+    if (match) {
+      if (match.id !== currentOrgId) dispatch(setCurrentOrganization(match.id))
+    } else {
+      navigate(`/${organizations[0].slug}`, { replace: true })
+    }
+  }, [orgSlug, organizations, isSuccess, currentOrgId, dispatch, navigate])
+
+  const waiting = isLoading || isFetching
+  if (waiting) return <OrgLoading />
+
+  const empty = isError || (isSuccess && (!data || data.length === 0))
+  if (empty) return <Navigate to="/no-organization" replace />
+
   return (
     <SidebarProvider>
       <AppSidebar />

--- a/ui/src/pages/no-organization.tsx
+++ b/ui/src/pages/no-organization.tsx
@@ -1,0 +1,30 @@
+import { Navigate } from 'react-router'
+import { useAppSelector } from '@/store/hooks'
+import { useListOrganizationsQuery, selectCurrentOrganization } from '@/store/organization'
+import { OrgLoading } from './org-loading'
+
+/**
+ * Shown when the user has no organizations. Placeholder until create-organization is implemented.
+ */
+export default function NoOrganizationPage() {
+  const { isLoading, isFetching, isSuccess, data } = useListOrganizationsQuery()
+  const current = useAppSelector(selectCurrentOrganization)
+
+  const waiting = isLoading || isFetching
+  if (waiting) return <OrgLoading />
+
+  if (isSuccess && data && data.length > 0) {
+    const slug = current?.slug ?? data[0].slug
+    return <Navigate to={`/${slug}`} replace />
+  }
+
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center gap-4 bg-background px-6 text-center">
+      <h1 className="text-xl font-semibold text-foreground">No organization yet</h1>
+      <p className="max-w-md text-sm text-muted-foreground">
+        You are not a member of any organization. A create-organization workflow will be available
+        here soon.
+      </p>
+    </div>
+  )
+}

--- a/ui/src/pages/org-loading.tsx
+++ b/ui/src/pages/org-loading.tsx
@@ -1,0 +1,10 @@
+import { Loader2 } from 'lucide-react'
+
+export function OrgLoading() {
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center gap-3 bg-background text-muted-foreground">
+      <Loader2 className="size-8 animate-spin" aria-hidden />
+      <p className="text-sm">Loading organizations…</p>
+    </div>
+  )
+}

--- a/ui/src/pages/org-root-redirect.tsx
+++ b/ui/src/pages/org-root-redirect.tsx
@@ -1,0 +1,22 @@
+import { Navigate } from 'react-router'
+import { useAppSelector } from '@/store/hooks'
+import { useListOrganizationsQuery, selectCurrentOrganization } from '@/store/organization'
+import { OrgLoading } from './org-loading'
+
+export function OrgRootRedirect() {
+  const { isLoading, isFetching, isSuccess, isError, data } = useListOrganizationsQuery()
+  const current = useAppSelector(selectCurrentOrganization)
+
+  const waiting = isLoading || isFetching
+  if (waiting) return <OrgLoading />
+
+  const empty = isError || (isSuccess && (!data || data.length === 0))
+  if (empty) return <Navigate to="/no-organization" replace />
+
+  if (isSuccess && data && data.length > 0) {
+    const slug = current?.slug ?? data[0]?.slug
+    if (slug) return <Navigate to={`/${slug}`} replace />
+  }
+
+  return <OrgLoading />
+}

--- a/ui/src/routes.tsx
+++ b/ui/src/routes.tsx
@@ -1,13 +1,17 @@
 import { Route, Routes, Navigate } from 'react-router'
 import Home from './pages/home'
 import Login from './pages/login'
-import { PrivateRoute, PublicRoute } from './components/auth'
+import NoOrganizationPage from './pages/no-organization'
+import { OrgRootRedirect } from './pages/org-root-redirect'
+import { PublicRoute } from './components/auth'
 
 export default function AppRoutes() {
   return (
     <Routes>
       <Route path="/login" element={<PublicRoute><Login /></PublicRoute>} />
-      <Route path="/" element={<PrivateRoute><Home /></PrivateRoute>} />
+      <Route path="/no-organization" element={<PublicRoute><NoOrganizationPage /></PublicRoute>} />
+      <Route path="/" element={<PublicRoute><OrgRootRedirect /></PublicRoute>} />
+      <Route path="/:orgSlug" element={<PublicRoute><Home /></PublicRoute>} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   )

--- a/ui/src/store/auth/api.ts
+++ b/ui/src/store/auth/api.ts
@@ -19,7 +19,9 @@ export const authApi = createApi({
           setToken(data.access_token)
           setUserData(data.user)
           dispatch(setCurrentUser(data.user))
-        } catch {}
+        } catch {
+          // Request failed or was aborted; leave auth state unchanged
+        }
       },
     }),
     signup: builder.mutation<AuthResponse, SignupData>({
@@ -30,7 +32,9 @@ export const authApi = createApi({
           setToken(data.access_token)
           setUserData(data.user)
           dispatch(setCurrentUser(data.user))
-        } catch {}
+        } catch {
+          // Request failed or was aborted; leave auth state unchanged
+        }
       },
     }),
     logout: builder.mutation<void, void>({
@@ -38,7 +42,11 @@ export const authApi = createApi({
       async onQueryStarted(_, { dispatch, queryFulfilled }) {
         clearAuthData()
         dispatch(clearCurrentUser())
-        try { await queryFulfilled } catch {}
+        try {
+          await queryFulfilled
+        } catch {
+          // Logout request may fail after local session was cleared
+        }
       },
     }),
   }),

--- a/ui/src/store/index.ts
+++ b/ui/src/store/index.ts
@@ -1,13 +1,16 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { authReducer, authApi } from './auth'
+import { organizationReducer, organizationApi } from './organization'
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    organization: organizationReducer,
     [authApi.reducerPath]: authApi.reducer,
+    [organizationApi.reducerPath]: organizationApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat(authApi.middleware),
+    getDefaultMiddleware().concat(authApi.middleware, organizationApi.middleware),
 })
 
 export type AppRootState = ReturnType<typeof store.getState>

--- a/ui/src/store/organization/api.ts
+++ b/ui/src/store/organization/api.ts
@@ -1,0 +1,26 @@
+import { createApi } from '@reduxjs/toolkit/query/react'
+import { createBaseQueryWithReauth } from '@/lib/api'
+import { MOCK_ORGANIZATIONS } from '@/lib/constants/organizations'
+import config from '@/config'
+import type { OrganizationSummary } from '@/types'
+
+/** Simulated latency so loading UI can be verified (ms). */
+const MOCK_ORG_LIST_DELAY_MS = 350
+
+export const organizationApi = createApi({
+  reducerPath: 'organizationApi',
+  baseQuery: createBaseQueryWithReauth(config.apiUrl),
+  tagTypes: ['Organization'],
+  endpoints: (builder) => ({
+    listOrganizations: builder.query<OrganizationSummary[], void>({
+      async queryFn() {
+        await new Promise((r) => setTimeout(r, MOCK_ORG_LIST_DELAY_MS))
+        const empty = import.meta.env.VITE_ORGS_EMPTY === 'true'
+        if (empty) return { data: [] as OrganizationSummary[] }
+        return { data: MOCK_ORGANIZATIONS }
+      },
+    }),
+  }),
+})
+
+export const { useListOrganizationsQuery } = organizationApi

--- a/ui/src/store/organization/index.ts
+++ b/ui/src/store/organization/index.ts
@@ -1,0 +1,15 @@
+export {
+  default as organizationReducer,
+  organizationSlice,
+  setCurrentOrganization,
+  restoreFromStorage,
+  resolveOrgId,
+  resolveOrgFromSlug,
+  selectOrganizations,
+  selectCurrentOrgId,
+  selectCurrentOrganization,
+  selectIsOrganizationInitialized,
+  selectOrgListLoaded,
+} from './slice'
+
+export { organizationApi, useListOrganizationsQuery } from './api'

--- a/ui/src/store/organization/slice.ts
+++ b/ui/src/store/organization/slice.ts
@@ -1,0 +1,100 @@
+import { createSlice } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
+import type { OrganizationSummary } from '@/types'
+import { organizationApi } from './api'
+
+const STORAGE_KEY = 'zenve-current-org-id'
+
+function readStoredOrgId(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+function writeStoredOrgId(id: string) {
+  try {
+    localStorage.setItem(STORAGE_KEY, id)
+  } catch {
+    /* ignore */
+  }
+}
+
+export function resolveOrgId(orgs: OrganizationSummary[], candidate: string | null): string {
+  if (!orgs.length) return ''
+  if (candidate && orgs.some((o) => o.id === candidate)) return candidate
+  return orgs[0].id
+}
+
+export function resolveOrgFromSlug(
+  orgs: OrganizationSummary[],
+  slug: string | undefined,
+): OrganizationSummary | null {
+  if (!slug) return null
+  return orgs.find((o) => o.slug === slug) ?? null
+}
+
+interface OrganizationState {
+  organizations: OrganizationSummary[]
+  currentOrgId: string
+  isInitialized: boolean
+  listLoaded: boolean
+}
+
+const initialState: OrganizationState = {
+  organizations: [],
+  currentOrgId: '',
+  isInitialized: false,
+  listLoaded: false,
+}
+
+export const organizationSlice = createSlice({
+  name: 'organization',
+  initialState,
+  reducers: {
+    setCurrentOrganization: (state, action: PayloadAction<string>) => {
+      const id = resolveOrgId(state.organizations, action.payload)
+      state.currentOrgId = id
+      writeStoredOrgId(id)
+    },
+    restoreFromStorage: (state) => {
+      const stored = readStoredOrgId()
+      state.currentOrgId = stored ?? ''
+      state.isInitialized = true
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addMatcher(organizationApi.endpoints.listOrganizations.matchFulfilled, (state, { payload }) => {
+      state.organizations = payload
+      state.listLoaded = true
+      const stored = state.currentOrgId || readStoredOrgId()
+      const resolved = resolveOrgId(payload, stored)
+      state.currentOrgId = resolved
+      writeStoredOrgId(resolved)
+    })
+    builder.addMatcher(organizationApi.endpoints.listOrganizations.matchRejected, (state) => {
+      state.organizations = []
+      state.listLoaded = true
+      state.currentOrgId = ''
+      writeStoredOrgId('')
+    })
+  },
+})
+
+export const { setCurrentOrganization, restoreFromStorage } = organizationSlice.actions
+
+export const selectOrganizations = (state: { organization: OrganizationState }) =>
+  state.organization.organizations
+export const selectCurrentOrgId = (state: { organization: OrganizationState }) =>
+  state.organization.currentOrgId
+export const selectCurrentOrganization = (state: { organization: OrganizationState }) => {
+  const { organizations, currentOrgId } = state.organization
+  return organizations.find((o) => o.id === currentOrgId) ?? organizations[0] ?? null
+}
+export const selectIsOrganizationInitialized = (state: { organization: OrganizationState }) =>
+  state.organization.isInitialized
+export const selectOrgListLoaded = (state: { organization: OrganizationState }) =>
+  state.organization.listLoaded
+
+export default organizationSlice.reducer

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -15,3 +15,20 @@ export interface SignupData {
   password: string
   name?: string
 }
+
+/** Discriminator for Lucide icon mapping in the UI (Redux stays serializable). */
+export type OrganizationIconKey =
+  | 'zap'
+  | 'triangle'
+  | 'box'
+  | 'cpu'
+  | 'building'
+  | 'layers'
+
+export interface OrganizationSummary {
+  id: string
+  name: string
+  slug: string
+  role: string
+  iconKey: OrganizationIconKey
+}

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -1,11 +1,9 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },
-    "ignoreDeprecations": "6.0",
     "target": "es2023",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "esnext",

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "files": [],
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }


### PR DESCRIPTION
## Summary

- Organization-scoped URLs (`/:orgSlug`) with URL ↔ Redux sync
- RTK Query org list (mock + optional empty state via `VITE_ORGS_EMPTY`)
- Full-screen org loading, `/no-organization` placeholder for future create-org flow
- Sidebar organization switcher with keyboard shortcuts
- shadcn UI and tooling updates bundled with this branch

## Notes

- Does not wire backend org membership; list is mock until API is connected.