### PR TITLE
Implement runs (chunk 08) with subprocess execution

### DIFF
--- a/server/apps/api/src/api/main.py
+++ b/server/apps/api/src/api/main.py
@@ -5,7 +5,14 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from api.lifespan import lifespan
-from api.routes import agent_router, api_key_router, auth_router, core_router, org_router
+from api.routes import (
+    agent_router,
+    api_key_router,
+    auth_router,
+    core_router,
+    org_router,
+    run_router,
+)
 
 app = FastAPI(lifespan=lifespan)
 
@@ -27,6 +34,7 @@ app.include_router(auth_router)
 app.include_router(org_router)
 app.include_router(api_key_router)
 app.include_router(agent_router)
+app.include_router(run_router)
 
 
 def main():

--- a/server/apps/api/src/api/routes/__init__.py
+++ b/server/apps/api/src/api/routes/__init__.py
@@ -3,5 +3,6 @@ from .api_key import router as api_key_router
 from .auth import router as auth_router
 from .core import router as core_router
 from .org import router as org_router
+from .run import router as run_router
 
-__all__ = ["agent_router", "api_key_router", "auth_router", "core_router", "org_router"]
+__all__ = ["agent_router", "api_key_router", "auth_router", "core_router", "org_router", "run_router"]

--- a/server/apps/api/src/api/routes/run.py
+++ b/server/apps/api/src/api/routes/run.py
@@ -1,0 +1,118 @@
+import asyncio
+
+from fastapi import APIRouter, Depends, Query, status
+
+from zenve_adapters.registry import AdapterRegistry
+from zenve_db.models import UserRecord
+from zenve_models.run import RunCreate, RunResponse, RunTranscript
+from zenve_services import (
+    get_adapter_registry,
+    get_membership_service,
+    get_org_service,
+    get_run_service,
+)
+from zenve_services.membership import MembershipService
+from zenve_services.org import OrgService
+from zenve_services.run import RunService
+from zenve_services.run_context import build_run_context
+from zenve_services.run_executor import execute_run
+from zenve_utils.auth import get_current_user
+
+router = APIRouter(prefix="/api/v1/orgs/{org_id}/runs", tags=["runs"])
+
+
+@router.post("", response_model=RunResponse, status_code=status.HTTP_202_ACCEPTED)
+def trigger_run(
+    org_id: str,
+    body: RunCreate,
+    user: UserRecord = Depends(get_current_user),
+    org_service: OrgService = Depends(get_org_service),
+    membership_service: MembershipService = Depends(get_membership_service),
+    run_service: RunService = Depends(get_run_service),
+    adapter_registry: AdapterRegistry = Depends(get_adapter_registry),
+):
+    org = org_service.get_by_id_or_slug(org_id)
+    membership_service.require_membership(user.id, org.id)
+
+    agent = run_service.get_agent_for_run(org.id, body.agent_id)
+    run = run_service.create_run(
+        org_id=org.id,
+        agent_id=agent.id,
+        trigger="manual",
+        adapter_type=agent.adapter_type,
+        message=body.message,
+    )
+
+    # Load organization onto agent so build_run_context can access org_slug
+    agent.organization = org
+
+    ctx = build_run_context(agent=agent, run_id=run.id, message=body.message)
+    asyncio.ensure_future(execute_run(run.id, ctx, adapter_registry))
+
+    return run
+
+
+@router.get("", response_model=list[RunResponse])
+def list_runs(
+    org_id: str,
+    agent_id: str | None = Query(None),
+    run_status: str | None = Query(None, alias="status"),
+    trigger: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    user: UserRecord = Depends(get_current_user),
+    org_service: OrgService = Depends(get_org_service),
+    membership_service: MembershipService = Depends(get_membership_service),
+    run_service: RunService = Depends(get_run_service),
+):
+    org = org_service.get_by_id_or_slug(org_id)
+    membership_service.require_membership(user.id, org.id)
+    return run_service.list_runs(org.id, agent_id=agent_id, status=run_status, trigger=trigger, limit=limit)
+
+
+@router.get("/{run_id}", response_model=RunResponse)
+def get_run(
+    org_id: str,
+    run_id: str,
+    user: UserRecord = Depends(get_current_user),
+    org_service: OrgService = Depends(get_org_service),
+    membership_service: MembershipService = Depends(get_membership_service),
+    run_service: RunService = Depends(get_run_service),
+):
+    org = org_service.get_by_id_or_slug(org_id)
+    membership_service.require_membership(user.id, org.id)
+    return run_service.get_by_id(org.id, run_id)
+
+
+@router.get("/{run_id}/transcript", response_model=RunTranscript)
+def get_transcript(
+    org_id: str,
+    run_id: str,
+    user: UserRecord = Depends(get_current_user),
+    org_service: OrgService = Depends(get_org_service),
+    membership_service: MembershipService = Depends(get_membership_service),
+    run_service: RunService = Depends(get_run_service),
+):
+    from fastapi import HTTPException
+
+    org = org_service.get_by_id_or_slug(org_id)
+    membership_service.require_membership(user.id, org.id)
+    run = run_service.get_by_id(org.id, run_id)
+    content = run_service.get_transcript(run)
+    if content is None:
+        raise HTTPException(status_code=404, detail="Transcript not available yet")
+    return RunTranscript(run_id=run_id, content=content)
+
+
+@router.delete("/{run_id}/cancel", response_model=RunResponse)
+def cancel_run(
+    org_id: str,
+    run_id: str,
+    user: UserRecord = Depends(get_current_user),
+    org_service: OrgService = Depends(get_org_service),
+    membership_service: MembershipService = Depends(get_membership_service),
+    run_service: RunService = Depends(get_run_service),
+):
+    org = org_service.get_by_id_or_slug(org_id)
+    membership_service.require_membership(user.id, org.id)
+    run = run_service.get_by_id(org.id, run_id)
+    return run_service.cancel_run(run)

--- a/server/packages/db/src/zenve_db/models.py
+++ b/server/packages/db/src/zenve_db/models.py
@@ -42,6 +42,9 @@ class Organization(Base):
     memberships: Mapped[list["UserOrgMembership"]] = relationship(
         back_populates="organization", cascade="all, delete-orphan"
     )
+    runs: Mapped[list["Run"]] = relationship(
+        back_populates="organization", cascade="all, delete-orphan"
+    )
 
 
 class UserOrgMembership(Base):
@@ -96,3 +99,26 @@ class Agent(Base):
     updated_at: Mapped[datetime] = mapped_column(default=func.now(), onupdate=func.now())
 
     organization: Mapped["Organization"] = relationship(back_populates="agents")
+    runs: Mapped[list["Run"]] = relationship(back_populates="agent", cascade="all, delete-orphan")
+
+
+class Run(Base):
+    __tablename__ = "runs"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    org_id: Mapped[str] = mapped_column(String(36), ForeignKey("organizations.id"), nullable=False)
+    agent_id: Mapped[str] = mapped_column(String(36), ForeignKey("agents.id"), nullable=False)
+    trigger: Mapped[str] = mapped_column(nullable=False)  # manual, heartbeat, webhook, collaboration
+    status: Mapped[str] = mapped_column(nullable=False, default="queued")  # queued, running, completed, failed, cancelled
+    adapter_type: Mapped[str] = mapped_column(nullable=False)
+    message: Mapped[str | None] = mapped_column(nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    exit_code: Mapped[int | None] = mapped_column(nullable=True)
+    error_summary: Mapped[str | None] = mapped_column(nullable=True)
+    token_usage: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    transcript_path: Mapped[str | None] = mapped_column(nullable=True)
+    created_at: Mapped[datetime] = mapped_column(default=func.now())
+
+    organization: Mapped["Organization"] = relationship(back_populates="runs")
+    agent: Mapped["Agent"] = relationship(back_populates="runs")

--- a/server/packages/models/src/zenve_models/run.py
+++ b/server/packages/models/src/zenve_models/run.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class RunCreate(BaseModel):
+    agent_id: str
+    message: str | None = None
+
+
+class RunResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    org_id: str
+    agent_id: str
+    trigger: str
+    status: str
+    adapter_type: str
+    message: str | None
+    started_at: datetime | None
+    finished_at: datetime | None
+    exit_code: int | None
+    error_summary: str | None
+    token_usage: dict | None
+    transcript_path: str | None
+    created_at: datetime
+
+
+class RunTranscript(BaseModel):
+    run_id: str
+    content: str

--- a/server/packages/services/src/zenve_services/__init__.py
+++ b/server/packages/services/src/zenve_services/__init__.py
@@ -10,6 +10,7 @@ from zenve_services.auth import AuthService
 from zenve_services.filesystem import FilesystemService
 from zenve_services.membership import MembershipService
 from zenve_services.org import OrgService
+from zenve_services.run import RunService
 
 
 def get_auth_service(db: Session = Depends(get_db)) -> AuthService:
@@ -44,3 +45,7 @@ def get_agent_service(
     adapter_registry: AdapterRegistry = Depends(get_adapter_registry),
 ) -> AgentService:
     return AgentService(db, filesystem, adapter_registry)
+
+
+def get_run_service(db: Session = Depends(get_db)) -> RunService:
+    return RunService(db)

--- a/server/packages/services/src/zenve_services/run.py
+++ b/server/packages/services/src/zenve_services/run.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from zenve_db.models import Agent, Run
+
+
+class RunService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_run(
+        self,
+        org_id: str,
+        agent_id: str,
+        trigger: str,
+        adapter_type: str,
+        message: str | None = None,
+        status: str = "queued",
+    ) -> Run:
+        run = Run(
+            org_id=org_id,
+            agent_id=agent_id,
+            trigger=trigger,
+            status=status,
+            adapter_type=adapter_type,
+            message=message,
+        )
+        self.db.add(run)
+        self.db.commit()
+        self.db.refresh(run)
+        return run
+
+    def get_by_id(self, org_id: str, run_id: str) -> Run:
+        run = self.db.get(Run, run_id)
+        if not run or run.org_id != org_id:
+            raise HTTPException(status_code=404, detail="Run not found")
+        return run
+
+    def list_runs(
+        self,
+        org_id: str,
+        agent_id: str | None = None,
+        status: str | None = None,
+        trigger: str | None = None,
+        limit: int = 50,
+    ) -> list[Run]:
+        q = self.db.query(Run).filter(Run.org_id == org_id)
+        if agent_id:
+            q = q.filter(Run.agent_id == agent_id)
+        if status:
+            q = q.filter(Run.status == status)
+        if trigger:
+            q = q.filter(Run.trigger == trigger)
+        return q.order_by(Run.created_at.desc()).limit(limit).all()
+
+    def update(self, run_id: str, **kwargs) -> Run:
+        run = self.db.get(Run, run_id)
+        if not run:
+            raise HTTPException(status_code=404, detail="Run not found")
+        for key, value in kwargs.items():
+            setattr(run, key, value)
+        self.db.commit()
+        self.db.refresh(run)
+        return run
+
+    def get_transcript(self, run: Run) -> str | None:
+        if not run.transcript_path:
+            return None
+        path = Path(run.transcript_path)
+        if not path.exists():
+            return None
+        return path.read_text(encoding="utf-8")
+
+    def has_active_run(self, agent_id: str) -> bool:
+        return (
+            self.db.query(Run)
+            .filter(Run.agent_id == agent_id, Run.status.in_(["queued", "running"]))
+            .first()
+            is not None
+        )
+
+    def cancel_run(self, run: Run) -> Run:
+        if run.status not in ("queued", "running"):
+            raise HTTPException(
+                status_code=409,
+                detail=f"Run cannot be cancelled (status: {run.status})",
+            )
+        run.status = "cancelled"
+        self.db.commit()
+        self.db.refresh(run)
+        return run
+
+    def get_agent_for_run(self, org_id: str, agent_id: str) -> Agent:
+        agent = (
+            self.db.query(Agent)
+            .filter(Agent.id == agent_id, Agent.org_id == org_id, Agent.status != "archived")
+            .first()
+        )
+        if not agent:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        return agent

--- a/server/packages/services/src/zenve_services/run_executor.py
+++ b/server/packages/services/src/zenve_services/run_executor.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from zenve_adapters.registry import AdapterRegistry
+from zenve_db.database import Session
+from zenve_db.models import Run
+from zenve_models.adapter import RunContext, RunResult
+
+logger = logging.getLogger(__name__)
+
+
+def _write_transcript(ctx: RunContext, result: RunResult) -> Path | None:
+    """Write run output to {agent_dir}/runs/{timestamp}_{run_id[:8]}.md"""
+    try:
+        runs_dir = Path(ctx.agent_dir) / "runs"
+        runs_dir.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
+        filename = f"{ts}_{ctx.run_id[:8]}.md"
+        path = runs_dir / filename
+        lines = [
+            f"# Run {ctx.run_id}",
+            f"- agent: {ctx.agent_slug}",
+            f"- exit_code: {result.exit_code}",
+            f"- duration: {result.duration_seconds:.2f}s",
+            "",
+            "## stdout",
+            "```",
+            result.stdout,
+            "```",
+        ]
+        if result.stderr:
+            lines += ["", "## stderr", "```", result.stderr, "```"]
+        path.write_text("\n".join(lines), encoding="utf-8")
+        return path
+    except Exception:
+        logger.exception("Failed to write transcript for run %s", ctx.run_id)
+        return None
+
+
+async def execute_run(
+    run_id: str,
+    ctx: RunContext,
+    adapter_registry: AdapterRegistry,
+) -> None:
+    """Background async task: execute one agent run and persist results.
+
+    Uses a fresh DB session (not FastAPI's Depends) since this runs outside
+    the request lifecycle.
+    """
+    db = Session()
+    try:
+        run: Run | None = db.get(Run, run_id)
+        if not run or run.status != "queued":
+            return
+
+        run.status = "running"
+        run.started_at = datetime.now(UTC)
+        db.commit()
+
+        adapter = adapter_registry.get(ctx.adapter_type)
+        result: RunResult = await adapter.execute(ctx)
+
+        transcript_path = _write_transcript(ctx, result)
+
+        # Re-fetch in case cancelled while running
+        db.refresh(run)
+        if run.status != "cancelled":
+            run.status = "completed" if result.exit_code == 0 else "failed"
+            run.exit_code = result.exit_code
+            run.token_usage = result.token_usage
+            run.transcript_path = str(transcript_path) if transcript_path else None
+            run.error_summary = result.error
+        run.finished_at = datetime.now(UTC)
+        db.commit()
+
+    except Exception as exc:
+        logger.exception("Run %s raised an unexpected error", run_id)
+        try:
+            db.rollback()
+            run = db.get(Run, run_id)
+            if run and run.status not in ("cancelled", "completed", "failed"):
+                run.status = "failed"
+                run.finished_at = datetime.now(UTC)
+                run.error_summary = str(exc)
+                db.commit()
+        except Exception:
+            logger.exception("Failed to mark run %s as failed after error", run_id)
+    finally:
+        db.close()


### PR DESCRIPTION
- Add Run ORM model with org/agent FKs and status lifecycle
- Add RunService for CRUD (create, get, list, update, cancel, transcript)
- Add run_executor.py: async background task using asyncio.ensure_future,
  writes transcript to {agent_dir}/runs/{ts}_{run_id[:8]}.md
- Add 5 REST endpoints under /api/v1/orgs/{org_id}/runs
  (POST trigger, GET list, GET detail, GET transcript, DELETE cancel)
- No Celery — runs fire via asyncio.ensure_future in the same process

https://claude.ai/code/session_014Qj7eMhfXYBPuqvpJtZb7e