### PR TITLE
docs: add org-level git versioning design (chunk 16)

### DIFF
--- a/agents/architect/docs/00-overview.md
+++ b/agents/architect/docs/00-overview.md
@@ -33,12 +33,13 @@ A self-hosted FastAPI REST gateway that manages organizations of AI agents, exec
 │  ┌─────▼──────────┐   ┌──────────────────────────┐  │
 │  │  SQLAlchemy     │   │  Agent Filesystem        │  │
 │  │  (Registry DB)  │   │  /data/orgs/{org}/       │  │
-│  │                 │   │    agents/{name}/         │  │
-│  │  - organizations│   │      SOUL.md             │  │
-│  │  - agents       │   │      AGENTS.md           │  │
-│  │  - runs         │   │      HEARTBEAT.md        │  │
-│  │  - api_keys     │   │      memory/             │  │
-│  └─────────────────┘   │      runs/ (transcripts) │  │
+│  │                 │   │    .git/  ← org git repo │  │
+│  │  - organizations│   │    agents/{name}/         │  │
+│  │  - agents       │   │      SOUL.md             │  │
+│  │  - runs         │   │      AGENTS.md           │  │
+│  │  - api_keys     │   │      HEARTBEAT.md        │  │
+│  └─────────────────┘   │      memory/             │  │
+│                         │      runs/ (gitignored)  │  │
 │                         └──────────────────────────┘  │
 └───────────────────────────┬───────────────────────────┘
                             │ Celery task dispatch
@@ -70,10 +71,10 @@ Four core database entities, plus a filesystem layer:
 - **Organizations** — top-level tenant. All entities are org-scoped.
 - **API Keys** — org-scoped, bcrypt-hashed, with granular scopes. Used by external callers.
 - **Agents** — registered in DB with metadata (adapter type, status, heartbeat config). Identity files live on disk.
-- **Runs** — execution records (queued → running → completed/failed/timeout). Transcripts stored on disk.
+- **Runs** — execution records (queued → running → completed/failed/timeout). Transcripts stored on disk. Each run records `pre_commit_sha` and `post_commit_sha` for diffing.
 - **Collaborations** — multi-agent group chat sessions with members, messages, and round-robin orchestration. Each turn creates a sub-run.
 
-Filesystem mirrors the DB: `/data/orgs/{slug}/agents/{slug}/` holds SOUL.md, AGENTS.md, HEARTBEAT.md, gateway.json, memory/, and run transcripts.
+Filesystem mirrors the DB: `/data/orgs/{slug}/` holds a single git repo (`.git/`) with all agent directories under `agents/{slug}/`, a shared `project/` directory, and run transcripts are gitignored.
 
 ## Tech Stack
 
@@ -106,6 +107,7 @@ Filesystem mirrors the DB: `/data/orgs/{slug}/agents/{slug}/` holds SOUL.md, AGE
 | 13 | Collaboration API & Messages   | 12         | Full REST API, message thread, cancel                | not started     | —          |
 | 14 | Health & Observability         | 07, 10     | /health, /health/workers, status checks              | not started     | —          |
 | 15 | Run Event System               | 05, 07, 08 | RunEvent model, on_event callback, event timeline API | not started     | —          |
+| 16 | Org-Level Git Versioning       | 07, 08     | OrgRepo helper, commit-per-run lifecycle, rollback, diff endpoint, remote push, org git config | not started     | —          |
 
 ## Cross-Cutting Concerns
 
@@ -113,6 +115,7 @@ Filesystem mirrors the DB: `/data/orgs/{slug}/agents/{slug}/` holds SOUL.md, AGE
 - **Dual identification** — All entities support UUID and slug lookup. UUID-first resolution, slug fallback.
 - **Hybrid storage** — DB for queryable metadata, filesystem for agent identity and full transcripts. `gateway.json` bridges the two worlds.
 - **Path safety** — All filesystem operations validate against path traversal. Agent dirs are sandboxed under org base_path.
+- **Org-level git versioning** — Each org has one git repo at its filesystem root. The gateway commits once per run after the adapter returns, recording `pre_commit_sha` and `post_commit_sha` on the run record. Concurrent commits serialize via a per-org lock (chunk 16).
 
 ## Key Decisions
 
@@ -131,6 +134,9 @@ Filesystem mirrors the DB: `/data/orgs/{slug}/agents/{slug}/` holds SOUL.md, AGE
 | Identity bridging | gateway.json + slug/UUID dual lookup | Filesystem stays human-readable, API stays programmatic. |
 | Agent auth at runtime | Short-lived JWT via env vars | Agents can discover peers without exposing org API keys. |
 | Multi-agent collaboration | Group chat + Celery-driven round-robin | Gateway orchestrates turns, agents only see shared messages. |
+| Org git versioning | One repo per org, commit per run | Single remote per org, coherent history, soft-delete audit trail. |
+| Git commit concurrency | Per-org Redis lock around commit step only | Adapters run in parallel; commits serialize for ~100ms each. |
+| Git remote push | `on_schedule` (5-min APScheduler) + manual | Default policy avoids noisy push-per-run; manual override via API. |
 
 ## Open Questions
 
@@ -143,3 +149,5 @@ Filesystem mirrors the DB: `/data/orgs/{slug}/agents/{slug}/` holds SOUL.md, AGE
 7. **gateway.json mutation policy** — Can agents modify their own gateway.json? May need guardrails to prevent capability escalation. *(affects chunks 03, 04)*
 8. **Collaboration context management** — Should there be compaction/summarization after N messages? *(affects chunk 12)*
 9. **Human-in-the-loop for collaborations** — Can a human post into an active collaboration mid-discussion? *(affects chunk 13)*
+10. **Shared-state write conflicts** — If two agents in a collaboration edit `project/specs.md` in the same round, merge conflicts are possible. Current collaboration model serializes turns, so this is a future concern. *(affects chunks 12, 16)*
+11. **History rewriting on hard delete** — Soft delete is the default. Hard-deleting an agent's history would require `git filter-repo` and is not exposed through the API. *(affects chunks 04, 16)*

--- a/agents/architect/docs/07-celery-run-execution.md
+++ b/agents/architect/docs/07-celery-run-execution.md
@@ -10,6 +10,7 @@ Set up Celery with Redis broker and implement the `execute_agent_run` task that 
 ## Referenced By
 - Chunk 08 — Runs CRUD (runs are dispatched as Celery tasks)
 - Chunk 15 — Run Event System (task builds on_event closure and emits lifecycle events)
+- Chunk 16 — Org-Level Git Versioning (commit step added to this task after adapter returns)
 
 ## Deliverables
 
@@ -60,6 +61,7 @@ def execute_agent_run(self, run_id: str):
     # 1. Get run + agent from DB
     run = run_service.get(run_id)
     agent = agent_service.get(run.agent_id)
+    org = org_service.get(run.org_id)
 
     # 2. Get adapter
     adapter = adapter_registry.get(agent.adapter_type)
@@ -67,17 +69,29 @@ def execute_agent_run(self, run_id: str):
     # 3. Mark as running
     run_service.update(run_id, status="running", started_at=utcnow())
 
+    # 4. Capture pre-run SHA (see Chunk 16)
+    org_repo = OrgRepo(org)
+    pre_sha = org_repo.head_sha()
+
     try:
-        # 4. Build context
+        # 5. Build context
         ctx = build_run_context(agent, run)
 
-        # 5. Execute via adapter
+        # 6. Execute via adapter
         result = adapter.execute(ctx)
 
-        # 6. Write transcript to disk
+        # 7. Write transcript to disk
         transcript_path = write_transcript(agent, run, result)
 
-        # 7. Update run record
+        # 8. Commit all changes made by the adapter (see Chunk 16)
+        post_sha = org_repo.commit_run(
+            agent_slug=agent.slug,
+            run_id=str(run.id),
+            trigger=run.trigger,
+            summary=result.summary or "",
+        )
+
+        # 9. Update run record
         run_service.update(run_id,
             status="completed" if result.exit_code == 0 else "failed",
             finished_at=utcnow(),
@@ -85,16 +99,43 @@ def execute_agent_run(self, run_id: str):
             token_usage=result.token_usage,
             transcript_path=transcript_path,
             error_summary=result.error,
+            pre_commit_sha=pre_sha,
+            post_commit_sha=post_sha,
         )
 
     except Exception as e:
+        # Rollback agent's own directory to pre-run state; shared project/ is kept
+        org_repo.rollback_agent(agent.slug, pre_sha, run_id=str(run.id))
+
         run_service.update(run_id,
             status="failed",
             finished_at=utcnow(),
             error_summary=str(e),
+            pre_commit_sha=pre_sha,
         )
         raise self.retry(exc=e)
 ```
+
+**Commit step detail** — `org_repo.commit_run()` must:
+1. Acquire the per-org lock (Redis lock in production, `asyncio.Lock` in dev).
+2. Run `git add -A`.
+3. Commit with author `{agent_slug} <{agent_slug}@{org_slug}.zenve.ai>` and message:
+   ```
+   run {run_id} ({trigger}): {short summary}
+
+   Run: {run_id}
+   Agent: {agent_slug}
+   Trigger: {heartbeat|manual|collaboration}
+   ```
+4. Return the new HEAD SHA.
+5. Release the lock.
+
+**Rollback detail** — `org_repo.rollback_agent()` runs:
+```
+git checkout <pre_sha> -- agents/<slug>/
+git commit -m "rollback run <run_id>"
+```
+Shared `project/` state is **not** rolled back.
 
 ### 5. Transcript Writer — `services/transcript.py`
 

--- a/agents/architect/docs/08-runs-crud.md
+++ b/agents/architect/docs/08-runs-crud.md
@@ -8,6 +8,7 @@ Implement the Run entity: ORM model, service, REST routes for triggering, listin
 
 ## Referenced By
 - Chunk 15 — Run Event System (run_events FK to runs, events endpoint alongside run routes)
+- Chunk 16 — Org-Level Git Versioning (pre/post SHA fields on Run; diff endpoint reads from org repo)
 
 ## Deliverables
 
@@ -32,6 +33,8 @@ runs
   transcript_path VARCHAR NULL          -- path to full transcript on disk
   celery_task_id  VARCHAR NULL          -- for task tracking/revocation
   collaboration_id UUID FK NULL         -- set for collaboration sub-runs (Chunk 11)
+  pre_commit_sha  VARCHAR(40) NULL      -- org repo HEAD before adapter ran (Chunk 16)
+  post_commit_sha VARCHAR(40) NULL      -- org repo HEAD after adapter committed (Chunk 16)
   created_at      TIMESTAMP
 ```
 
@@ -60,6 +63,8 @@ class RunResponse(BaseModel):
     token_usage: dict | None
     celery_task_id: str | None
     collaboration_id: UUID | None
+    pre_commit_sha: str | None
+    post_commit_sha: str | None
     created_at: datetime
 
 class RunTranscript(BaseModel):
@@ -136,6 +141,12 @@ GET    /api/v1/runs/{run_id}/transcript → get full transcript
 DELETE /api/v1/runs/{run_id}/cancel    → cancel a running task
   - Revokes Celery task
   - Marks run as failed
+
+GET    /api/v1/runs/{run_id}/diff      → git diff for this run (Chunk 16)
+  Query: ?include_shared=false
+  - Diffs pre_commit_sha..post_commit_sha scoped to agents/{agent_slug}/
+  - With include_shared=true also includes project/
+  - Returns 404 if pre_commit_sha or post_commit_sha is null
 ```
 
 ### 6. Register Router
@@ -149,3 +160,5 @@ Add run_router to `api/routes/__init__.py`.
 - The `cancel` endpoint uses Celery's `revoke()` with `terminate=True`.
 - `has_active_run()` is used by the heartbeat scheduler to avoid double-scheduling.
 - Transcript is read from disk, not stored in the database (keeps DB lean).
+- `pre_commit_sha` and `post_commit_sha` are set by the Celery task (Chunk 07) after the adapter runs. Both are null until the run completes.
+- The diff endpoint path-scopes the diff to the agent's own directory, so unrelated concurrent commits don't pollute the output.

--- a/agents/architect/docs/16-org-git-versioning.md
+++ b/agents/architect/docs/16-org-git-versioning.md
@@ -1,0 +1,181 @@
+# Chunk 16 — Org-Level Git Versioning
+
+## Goal
+Give each organization a single git repository at its filesystem root. The gateway commits once per agent run — after the adapter returns — using a thin `OrgRepo` helper. Agents never interact with git directly.
+
+## Depends On
+- Chunk 07 (Celery Run Execution — commit step is added to `execute_agent_run`)
+- Chunk 08 (Runs CRUD — `pre_commit_sha` / `post_commit_sha` fields on the Run model)
+
+## Referenced By
+- Chunk 10 — Heartbeat Scheduler (heartbeat runs are committed by the same lifecycle)
+- Chunk 12 — Collaboration Execution Engine (collaboration sub-runs go through the same commit step)
+
+## Filesystem Layout
+
+```
+/data/orgs/{org_slug}/
+  .git/                 ← one repo per org
+  .gitignore            ← ignores agents/*/runs/
+  project/              ← shared org-level state (specs, docs, context)
+  agents/
+    {agent_slug}/
+      gateway.json
+      SOUL.md
+      AGENTS.md
+      memory/
+      workspace/
+      runs/             ← gitignored (transcripts)
+```
+
+## Deliverables
+
+### 1. Dependencies
+
+Add to project:
+- `GitPython`
+
+### 2. OrgRepo Helper — `services/org_repo.py`
+
+Wraps all git operations. The Celery task calls this; no raw git calls inline in tasks.
+
+```python
+class OrgRepo:
+    def __init__(self, org: Organization): ...
+
+    def init_if_needed(self) -> None:
+        """Initialize git repo and .gitignore if org dir has no .git."""
+
+    def head_sha(self) -> str | None:
+        """Return current HEAD sha, or None if repo has no commits."""
+
+    def commit_run(
+        self,
+        agent_slug: str,
+        run_id: str,
+        trigger: str,
+        summary: str,
+    ) -> str:
+        """
+        Acquire per-org lock, stage all changes, commit, release lock.
+        Returns the new HEAD sha.
+        """
+
+    def rollback_agent(
+        self,
+        agent_slug: str,
+        pre_sha: str,
+        run_id: str,
+    ) -> None:
+        """
+        Restore agents/{agent_slug}/ to pre_sha and commit the rollback.
+        Does NOT touch project/.
+        """
+```
+
+### 3. Commit Convention
+
+**Author:** `{agent_slug} <{agent_slug}@{org_slug}.zenve.ai>`
+
+**Message:**
+```
+run {run_id} ({trigger}): {short summary}
+
+Run: {run_id}
+Agent: {agent_slug}
+Trigger: {heartbeat|manual|collaboration}
+```
+
+This enables three filter styles out of the box:
+```bash
+git log -- agents/devy/        # by path
+git log --author=devy          # by author
+git log --grep="Run: abc123"   # by run id
+```
+
+### 4. Commit Lifecycle in `execute_agent_run`
+
+```
+1. pre_sha  = org_repo.head_sha()
+2. adapter.execute(ctx)             ← agent writes files freely
+3. org_repo.commit_run(...)         ← acquire lock, git add -A, commit, release
+4. post_sha = new HEAD
+5. run_service.update(pre_commit_sha=pre_sha, post_commit_sha=post_sha)
+```
+
+On adapter exception:
+```
+org_repo.rollback_agent(agent_slug, pre_sha, run_id)
+run_service.update(pre_commit_sha=pre_sha, status="failed")
+```
+
+### 5. Concurrency Lock
+
+Git takes a per-repo index lock; concurrent commits within the same org must serialize.
+
+- **Production:** Redis distributed lock (`{org_slug}:git_lock`, TTL 30s).
+- **Dev / test:** Per-process `asyncio.Lock` keyed by org slug, stored in a module-level dict.
+
+The lock wraps only the commit step, not adapter execution. Adapters run fully in parallel; commits serialize for a few hundred milliseconds each.
+
+### 6. Data Model Additions — `db/models.py`
+
+Add columns to `organizations`:
+
+```
+git_remote_url      VARCHAR NULL
+git_remote_name     VARCHAR DEFAULT 'origin'
+git_push_policy     VARCHAR DEFAULT 'on_schedule'  -- manual | on_commit | on_schedule
+last_pushed_at      TIMESTAMP NULL
+last_pushed_sha     VARCHAR NULL
+```
+
+Add columns to `runs`:
+
+```
+pre_commit_sha      VARCHAR(40) NULL
+post_commit_sha     VARCHAR(40) NULL
+```
+
+### 7. Remote Push
+
+Default policy is `on_schedule` with a 5-minute APScheduler job. Users can also trigger a manual push:
+
+```
+POST /api/v1/orgs/{id}/git/push    → trigger immediate push to configured remote
+GET  /api/v1/orgs/{id}/git/status  → last_pushed_at, last_pushed_sha, push errors
+```
+
+Transient push failures are retried (up to 3×). Persistent failures surface on the status endpoint. Remote credentials live in the secrets store, not the DB.
+
+### 8. Diff Endpoint — `api/routes/run.py`
+
+```
+GET /api/v1/runs/{run_id}/diff
+  → git diff <pre_sha>..<post_sha> -- agents/{agent_slug}/
+
+GET /api/v1/runs/{run_id}/diff?include_shared=true
+  → git diff <pre_sha>..<post_sha> -- agents/{agent_slug}/ project/
+```
+
+Path scoping keeps the diff focused on what this specific run changed, even when other runs committed in between.
+
+Returns 404 if `pre_commit_sha` or `post_commit_sha` is null (run did not complete a commit).
+
+### 9. .gitignore Template
+
+The `.gitignore` written at `init_if_needed()` time:
+
+```
+agents/*/runs/
+*.pyc
+__pycache__/
+```
+
+## Notes
+
+- `OrgRepo.init_if_needed()` is called by `FilesystemService.create_org_dir()` (Chunk 03) so every org starts with a git repo.
+- GitPython's `Repo` object should be instantiated once per task invocation, not cached across tasks.
+- `head_sha()` returns `None` on a freshly initialized repo (no commits yet); the task must handle this case and skip the rollback if `pre_sha` is `None`.
+- `.git` size growth is handled by periodic `git gc`; not a near-term concern.
+- Hard-deleting an agent's history (e.g. with `git filter-repo`) is not exposed through the API. Soft delete is the default.


### PR DESCRIPTION
Introduces a new architecture chunk describing per-org git repos with
a commit-per-run lifecycle. Updates the overview, Celery task, and Runs
CRUD docs to reflect pre/post SHA tracking, the OrgRepo helper, rollback
on failure, the diff endpoint, and remote push policy.

https://claude.ai/code/session_01LF53SSPBVAvdwTffpRdf3Q